### PR TITLE
Priority/feature 01 add vue router for navigation

### DIFF
--- a/dev/gen-publishing-note-files.sh
+++ b/dev/gen-publishing-note-files.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+dir=/home/olfreg314/notes/org-export/files-approved/
+prjdir=/home/olfreg314/projects/prjolfreg314/
+
+cd ${dir}
+make
+cd ${prjdir}

--- a/dev/insert-template-tag.sh
+++ b/dev/insert-template-tag.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+dir=./src/components/notes/publish
+
+for file in ${dir}/*.vue; do
+  sed -i "1 i\ <template>" ${file}
+  sed -i "$ a\ </template>" ${file}
+done

--- a/dev/modify-extension.sh
+++ b/dev/modify-extension.sh
@@ -1,0 +1,7 @@
+#/bin/sh
+
+dir=./src/components/notes/publish
+
+for file in ${dir}/*.html;do
+  mv -- "$file" "${file%.html}.vue"
+done

--- a/dev/modify-file-name.sh
+++ b/dev/modify-file-name.sh
@@ -1,0 +1,24 @@
+#/bin/sh
+
+dir=./src/components/notes/publish
+
+
+cd $dir
+for file in *.vue;do
+  # sed 's/^\(.\)/\U\1/':
+  #   s/: Starts the substitution command in sed.
+  #   ^: Anchors the match to the start of the line.
+  #   \(.\): Captures the first character. \( ... \) is used for capturing groups in sed.
+  #   \U: Tells sed to convert the following character to uppercase.
+  #   \1: References the first captured group (the first character).
+  capitalized_first_letter=$(echo "$file" | sed 's/^\(.\)/\U\1/')
+  # sed -r 's/-(.)/\U\1/g':
+  #   -r: Enables extended regular expressions in sed (which allows \U to work properly).
+  #   s/: Starts the substitution command in sed.
+  #   -(.): Matches a hyphen followed by any character. The parentheses capture the character after the hyphen.
+  #   \U: Tells sed to convert the following character to uppercase.
+  #   \1: References the first captured group (the character after the hyphen).
+  #   g: Applies the substitution globally to all matches in the string.
+  converted_filename=$(echo "$capitalized_first_letter" | sed -r 's/-(.)/\U\1/g')
+  mv "$file" "$converted_filename"
+done

--- a/package.json
+++ b/package.json
@@ -5,7 +5,13 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "ntsync": "rsync -avv --info=progress2 --copy-links /home/olfreg314/notes/org-export/publish ./src/components/notes",
+    "ntmodifyext": "sh ./dev/modify-extension.sh",
+    "ntinserttag": "sh ./dev/insert-template-tag.sh",
+    "ntmodifyfilename": "sh ./dev/modify-file-name.sh",
+    "ntpublish": "sh ./dev/gen-publishing-note-files.sh",
+    "generatent": "npm run ntpublish && npm run ntsync && npm run ntmodifyext && npm run ntinserttag && npm run ntmodifyfilename exit"
   },
   "dependencies": {
     "core-js": "^3.8.3",

--- a/public/output.css
+++ b/public/output.css
@@ -516,8 +516,20 @@ video {
   --tw-backdrop-sepia:  ;
 }
 
-.absolute {
-  position: absolute;
+.visible {
+  visibility: visible;
+}
+
+.invisible {
+  visibility: hidden;
+}
+
+.fixed {
+  position: fixed;
+}
+
+.sticky {
+  position: sticky;
 }
 
 .inset-x-0 {
@@ -527,6 +539,10 @@ video {
 
 .bottom-24 {
   bottom: 6rem;
+}
+
+.bottom-8 {
+  bottom: 2rem;
 }
 
 .mx-auto {
@@ -560,8 +576,28 @@ video {
   margin-top: 2rem;
 }
 
+.block {
+  display: block;
+}
+
 .flex {
   display: flex;
+}
+
+.table {
+  display: table;
+}
+
+.grid {
+  display: grid;
+}
+
+.hidden {
+  display: none;
+}
+
+.h-3 {
+  height: 0.75rem;
 }
 
 .h-6 {
@@ -579,6 +615,10 @@ video {
 
 .w-1 {
   width: 0.25rem;
+}
+
+.w-96 {
+  width: 24rem;
 }
 
 .w-fit {
@@ -601,6 +641,10 @@ video {
 
 .justify-center {
   justify-content: center;
+}
+
+.overflow-x-scroll {
+  overflow-x: scroll;
 }
 
 .rounded-md {
@@ -638,6 +682,11 @@ video {
 .px-5 {
   padding-left: 1.25rem;
   padding-right: 1.25rem;
+}
+
+.py-1 {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
 }
 
 .py-4 {
@@ -679,6 +728,20 @@ video {
 .text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+.outline-2 {
+  outline-width: 2px;
+}
+
+.outline-4 {
+  outline-width: 4px;
+}
+
+.ring {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
 }
 
 /* @import url("https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;400;500;600;700&display=swap"); */

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import DroidNav from "@/components/droid-nav.vue";
+import DroidNav from "@/components/DroidNav.vue";
 </script>
 
 <template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,9 @@
 <script setup>
-import HomePage from "@/views/HomePage.vue";
-
 import DroidNav from "@/components/droid-nav.vue";
 </script>
 
 <template>
-  <HomePage />
+  <RouterView />
   <DroidNav />
 </template>
 

--- a/src/components/DroidNav.vue
+++ b/src/components/DroidNav.vue
@@ -14,7 +14,7 @@ function toHome() {
 <template>
   <section
     id="droid-nav"
-    class="absolute bottom-24 inset-x-0 text-white font-iosevkaext"
+    class="fixed bottom-8 inset-x-0 text-white font-iosevkaext"
   >
     <div
       class="flex w-fit mx-auto px-16 py-4 justify-center bg-cstm_black rounded-md"
@@ -24,7 +24,6 @@ function toHome() {
         class="px-5 flex items-center hover:text-cstm_red"
       >
         <div class="current-active mr-2.5 rounded-sm my-0 w-1 h-6"></div>
-        <!-- <RouterLink to="/">Home</RouterLink> -->
         Home
       </button>
       <button
@@ -32,7 +31,6 @@ function toHome() {
         class="px-5 flex items-center hover:text-cstm_red"
       >
         <div class="mr-2.5 rounded-sm my-0 w-1 h-6"></div>
-        <!-- <RouterLink to="/notesvault">Notes</RouterLink> -->
         Notes
       </button>
     </div>

--- a/src/components/NotesContentViewer.vue
+++ b/src/components/NotesContentViewer.vue
@@ -1,0 +1,54 @@
+<script setup></script>
+<template>
+  <section id="section-notes-container" class="grid font-iosevkaext text-white">
+    <RouterView />
+  </section>
+</template>
+<style scope>
+#table-of-contents {
+  padding-top: 4rem;
+  padding-bottom: 4rem;
+  h2 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    padding-bottom: 1.5rem;
+  }
+  ul {
+    list-style-position: outsite;
+    padding-bottom: 1.125rem;
+    li {
+      font-weight: 700;
+    }
+    li {
+      ul {
+        padding-left: 3ch;
+        li {
+          font-weight: 500;
+        }
+      }
+    }
+  }
+}
+
+.outline-2 {
+  padding-bottom: 1.5rem;
+  h2 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    padding-bottom: 1.125rem;
+  }
+}
+#section-notes-container {
+  word-wrap: break-word;
+  white-space: per-line;
+}
+table {
+  margin-top: 1.125rem;
+  margin-bottom: 1.125rem;
+  overflow-x: auto;
+  width: 100v;
+  tr {
+    border-bottom: 1px solid;
+  }
+}
+</style>

--- a/src/components/NotesListDroidNav.vue
+++ b/src/components/NotesListDroidNav.vue
@@ -1,0 +1,49 @@
+<script setup>
+import { useRouter } from "vue-router";
+import { ref } from "vue";
+
+const router = useRouter();
+
+const notesVaultAvailableRoutes = ref(router.options.routes[1].children);
+console.log(notesVaultAvailableRoutes);
+function loadNotePage(note) {
+  console.log(note);
+  router.push({ path: `/notesvault/${note.toLowerCase()}` });
+}
+</script>
+
+<template>
+  <section
+    id="notes-list-droid-nav"
+    class="fixed bottom-24 inset-x-0 text-white font-iosevkaext"
+  >
+    <div
+      class="flex w-96 mx-auto px-16 py-1 justify-center bg-cstm_black rounded-md overflow-x-scroll"
+    >
+      <button
+        v-for="route in notesVaultAvailableRoutes"
+        :key="route"
+        @click="loadNotePage(route.path)"
+        class="px-5 flex items-center hover:text-cstm_red"
+      >
+        <div class="mr-2.5 rounded-sm my-0 w-1 h-3"></div>
+        {{ route.path }}
+      </button>
+      <button
+        @click="loadNotePage('cpuArchitecture')"
+        class="px-5 flex items-center hover:text-cstm_red"
+      >
+        <div class="mr-2.5 rounded-sm my-0 w-1 h-3"></div>
+        Cpu Architecture
+      </button>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.current-active {
+  content: "";
+  background-color: #8bd49c;
+  display: inline-block;
+}
+</style>

--- a/src/components/droid-nav.vue
+++ b/src/components/droid-nav.vue
@@ -1,4 +1,15 @@
-<script setup></script>
+<script setup>
+import { useRouter } from "vue-router";
+
+const router = useRouter();
+function toNotesVault() {
+  router.push({ path: "/notesvault" });
+}
+
+function toHome() {
+  router.push({ path: "/" });
+}
+</script>
 
 <template>
   <section
@@ -8,13 +19,21 @@
     <div
       class="flex w-fit mx-auto px-16 py-4 justify-center bg-cstm_black rounded-md"
     >
-      <button class="px-5 flex items-center hover:text-cstm_red">
+      <button
+        @click="toHome"
+        class="px-5 flex items-center hover:text-cstm_red"
+      >
         <div class="current-active mr-2.5 rounded-sm my-0 w-1 h-6"></div>
-        <div>Home</div>
+        <!-- <RouterLink to="/">Home</RouterLink> -->
+        Home
       </button>
-      <button class="px-5 flex items-center hover:text-cstm_red">
+      <button
+        @click="toNotesVault"
+        class="px-5 flex items-center hover:text-cstm_red"
+      >
         <div class="mr-2.5 rounded-sm my-0 w-1 h-6"></div>
-        <div>Notes</div>
+        <!-- <RouterLink to="/notesvault">Notes</RouterLink> -->
+        Notes
       </button>
     </div>
   </section>

--- a/src/components/notes/publish/NtArch.vue
+++ b/src/components/notes/publish/NtArch.vue
@@ -1,0 +1,1021 @@
+ <template>
+<div id="table-of-contents" role="doc-toc">
+<h2>Table of Contents</h2>
+<div id="text-table-of-contents" role="doc-toc">
+<ul>
+<li><a href="#org634a182">1. Application List</a></li>
+<li><a href="#org170310e">2. How to install Arch ref guide</a></li>
+<li><a href="#org87264fe">3. How to manage <code>.dot</code> files</a>
+<ul>
+<li><a href="#orgd7791e5">3.1. Push to github</a></li>
+</ul>
+</li>
+<li><a href="#org797a4fe">4. How to cofigure clipboard in wayland (Hyprland)</a></li>
+<li><a href="#org5608a8f">5. How to set screen capturing</a></li>
+<li><a href="#org16dddf6">6. How to convert from .md to .org</a></li>
+<li><a href="#org749b84c">7. How to change escape key to other key in Archcraft</a></li>
+<li><a href="#org5464ed3">8. REVISION Unexpected crash shutdown in Archcraft</a></li>
+<li><a href="#org063c312">9. xbacklight not working in Archcraft</a></li>
+<li><a href="#org82c7f50">10. optimus-manager causing screen tearing in Archcraft</a></li>
+<li><a href="#orgf19df07">11. How to get temperature record in Archcraft</a></li>
+<li><a href="#org4e6b644">12. How to customize touchpad to work on firefox</a></li>
+<li><a href="#orgb03f23d">13. Security tools</a></li>
+<li><a href="#org98cc8de">14. Custom fan control in MSI GF63-thin 9SCXR</a></li>
+<li><a href="#orgf37154e">15. plocate and locate</a></li>
+<li><a href="#orgb6a6823">16. How to toggle hide/unhide for an application through keyboard shortcut in bspwm inside Archcraft</a></li>
+<li><a href="#org24676aa">17. How to use rsync</a></li>
+<li><a href="#orgfdf4f08">18. How to modify drives status</a></li>
+<li><a href="#orga2a65c0">19. IDE (Integrate Drive Electronics)</a></li>
+<li><a href="#orgba5889f">20. Sound and Video stopped after update of pipewire Archcraft</a></li>
+<li><a href="#orgedd2137">21. wireplumber and pipewire-media-session are in conflict in Archcraft</a></li>
+<li><a href="#org68908a6">22. rfkill</a></li>
+<li><a href="#org3401299">23. failed to commit transaction (conflicting files)</a>
+<ul>
+<li><a href="#orgb44b608">23.1. Ignore the package which are creating problme</a></li>
+<li><a href="#org4954217">23.2. Overwrite files</a></li>
+<li><a href="#orgbec9caf">23.3. Check if any pkg owns the file</a></li>
+</ul>
+</li>
+<li><a href="#orgc519084">24. Unhide a window in bspwm in Archcraft</a></li>
+<li><a href="#org5bef9ce">25. If pacman package got deleted</a></li>
+<li><a href="#orgccd8dde">26. duf (shows about the disk)</a></li>
+<li><a href="#orgd76165b">27. Start xfce4-terminal in float mode in Archcraft</a></li>
+<li><a href="#org4d9a297">28. git error: unsafe repo</a></li>
+<li><a href="#org5cbe1c1">29. Blank screen after boot in Archcraft</a>
+<ul>
+<li><a href="#org90e34b0">29.1. Arch chroot sanatize it</a></li>
+</ul>
+</li>
+<li><a href="#org59ea26b">30. Additional monitor connection</a></li>
+<li><a href="#orgc206664">31. xev</a></li>
+<li><a href="#orgfb7baef">32. change ls output color</a></li>
+<li><a href="#orgb0fca6b">33. Setup RAG</a></li>
+</ul>
+</div>
+</div>
+<p>
+#+Created : 07 Jan 24
+#+Modified : 26 Apr 24
+</p>
+
+
+<section id="outline-container-org634a182" class="outline-2">
+<h2 id="org634a182"><span class="section-number-2">1.</span> Application List</h2>
+<div class="outline-text-2" id="text-1">
+<table>
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<thead>
+<tr>
+<th scope="col" class="org-left">Package</th>
+<th scope="col" class="org-left">Command</th>
+<th scope="col" class="org-left">Description</th>
+<th scope="col" class="org-left">Issue</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="org-left">flatpak</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Universal pkg manager</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">xev</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Gets input device event updates</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">mons</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Controls secondary monitor</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">ranger</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Cmd line file mngr</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+</tbody>
+</table>
+</div>
+</section>
+
+<section id="outline-container-org170310e" class="outline-2">
+<h2 id="org170310e"><span class="section-number-2">2.</span> How to install Arch ref guide</h2>
+<div class="outline-text-2" id="text-2">
+<ol class="org-ol">
+<li>Torrent the Arch iso(uncompressed completed image of optical disk)
+<ol class="org-ol">
+<li>Check the integrity of the downloaded iso by <code>cksum -a sha256 file.iso</code></li>
+</ol></li>
+<li>Flash the iso into pendrive</li>
+<li>Boot into the live arch</li>
+<li>Do the partitioning</li>
+<li>Mount the partition</li>
+<li>Install base linux into the root partitioned
+<ol class="org-ol">
+<li><code>pacstrap base linux linux-firmware</code></li>
+</ol></li>
+<li>Arch chroot into the system by <code>arch-chroot</code></li>
+<li>Configuration
+<ol class="org-ol">
+<li>Network
+<ul class="org-ul">
+<li>Check correct drivers is installed
+<ol class="org-ol">
+<li><code>lspci | grep network | less</code></li>
+<li><code>dmesg | grep firmware</code></li>
+</ol></li>
+<li>Enale built-in wifi manager iwd
+<ol class="org-ol">
+<li><code>systemctl enable iwd.service</code></li>
+<li><code>systemctl enable systemd-resolved.service</code></li>
+<li>Use through <code>iwctl</code></li>
+</ol></li>
+<li>Make sure there is no conflicting network manager installed</li>
+<li><code>/sys/class/net</code>, list of network interface available</li>
+</ul></li>
+<li>Language
+<ol class="org-ol">
+<li><code>locale-gen</code></li>
+<li>uncomment/write <code>LANG=en_US.UTF-</code> in file <code>/etc/locale.conf</code></li>
+</ol></li>
+<li><code>/etc/hostname</code></li>
+</ol></li>
+<li>Restart.</li>
+<li>Configure user groups</li>
+</ol>
+</div>
+</section>
+
+<section id="outline-container-org87264fe" class="outline-2">
+<h2 id="org87264fe"><span class="section-number-2">3.</span> How to manage <code>.dot</code> files</h2>
+<div class="outline-text-2" id="text-3">
+<p>
+Dot files are simple configuration file that contains rules specific to the program written in a specific protocol as directed by the prgram maintainer.
+</p>
+
+<ol class="org-ol">
+<li>Create dir <code>dir_name (.dotfiles)</code>, contains all the configuration files.</li>
+<li>Create make file <code>makefile</code>, for automation of build process.
+<ul class="org-ul">
+<li>Make files are used by <code>make</code> command for running set of commands, basically we can automate some repeating and obious commands through it.</li>
+<li>Why
+<ul class="org-ul">
+<li>We have to simlink the files to there actuall location when using it in another system. So either we have to do it manually in which we also have to make sure the files are getting link on correct path. So its better to automate this task with make file.</li>
+</ul></li>
+</ul></li>
+<li><code>mv ~~/.emacs.d/init.el ~~/.dotfiles/</code></li>
+<li><code>ln -sf ~/.dotfiles/init.el ~/.emacs.d/init.el</code>, will create a simlink from the <code>~/.dotfiles/init.el</code> to <code>~/.emacs.d/init.el</code>.</li>
+<li>Make file automation, to automate the simlink process.</li>
+</ol>
+<div class="org-src-container">
+<pre class="src src-makefile">linkemacsfiles: init.el
+mkdir -p ~/.emacs.d/
+ln -sf ~/.dotfiles/init.el ~/.emacs.d/init.el
+</pre>
+</div>
+</div>
+
+<div id="outline-container-orgd7791e5" class="outline-3">
+<h3 id="orgd7791e5"><span class="section-number-3">3.1.</span> Push to github</h3>
+<div class="outline-text-3" id="text-3-1">
+<div class="org-src-container">
+<pre class="src src-shell">git pull 
+git commit -m "Added init.el"
+remote add main https://github.com/olfREG314/.dotfiles
+git push --set-upstream main master
+</pre>
+</div>
+</div>
+</div>
+</section>
+
+<section id="outline-container-org797a4fe" class="outline-2">
+<h2 id="org797a4fe"><span class="section-number-2">4.</span> How to cofigure clipboard in wayland (Hyprland)</h2>
+<div class="outline-text-2" id="text-4">
+<p>
+Wayland provides support through `wl-copy` &amp; `wl-paste` in package `wl-clipboard`.
+Most application by default configured `C+c` `C+v` with system clipboard writing like firefox, Alacritty, etc. But application like vim is not, Vim has multiple clipboard within its application so `yank` `paste` usually do not go directly to system clipboard but to vim inbuilt which is `&ldquo;*` unnamed.
+</p>
+
+<p>
+But it also provide way to copy to system clipboard throuth `&ldquo;+` unnamedplus.
+</p>
+<ul class="org-ul">
+<li><code>set clipboard=unnamedplus</code>  
+<ul class="org-ul">
+<li>it will only work in X11 but not in wayland.
+<ul class="org-ul">
+<li>to configure it in wayland
+<ul class="org-ul">
+<li>install <code>vim-wayland-clipboard</code></li>
+<li><a href="https://github.com/jasonccox/vim-wayland-clipboard">https://github.com/jasonccox/vim-wayland-clipboard</a></li>
+</ul></li>
+<li><code>copyq</code>: clipboard manager
+<ul class="org-ul">
+<li><code>exec-once = copyq --start-server</code> : enabling it on statup on Hyprland.</li>
+</ul></li>
+<li>vim with +clipboard +eval need to be enabled
+<ul class="org-ul">
+<li>Normal vim installing will not have this enabled.</li>
+<li>Installing `gvim` will enable this by default, chek using `vim &#x2013;version`</li>
+</ul></li>
+</ul></li>
+</ul></li>
+<li>Ref
+<ul class="org-ul">
+<li><a href="https://vi.stackexchange.com/questions/84/how-can-i-copy-text-to-the-system-clipboard-from-vim">https://vi.stackexchange.com/questions/84/how-can-i-copy-text-to-the-system-clipboard-from-vim</a></li>
+<li><a href="https://wiki.archlinux.org/title/Clipboard">https://wiki.archlinux.org/title/Clipboard</a>&lt;F2&gt;</li>
+</ul></li>
+</ul>
+</div>
+</section>
+
+<section id="outline-container-org5608a8f" class="outline-2">
+<h2 id="org5608a8f"><span class="section-number-2">5.</span> How to set screen capturing</h2>
+<div class="outline-text-2" id="text-5">
+<ul class="org-ul">
+<li>using <code>grim</code> &amp; <code>slurp</code> - grim for capture in wayland &amp; slurp for region selection
+<ul class="org-ul">
+<li>configured in Hyprland config -&gt; added sortcut</li>
+</ul></li>
+</ul>
+<div class="org-src-container">
+<pre class="src src-conf">bind = $mainMod, p, exec, grim -g "$(slurp -d)" - | wl-copy
+bind = $mainMod SHIFT, p, exec, grim 
+</pre>
+</div>
+<ul class="org-ul">
+<li>configured in <code>.bashrc</code> -&gt; added env variable
+<ul class="org-ul">
+<li>export <code>GRIM_DEFAULT_DIR="/home/olfreg314/screenshots/"</code></li>
+</ul></li>
+</ul>
+</div>
+</section>
+
+<section id="outline-container-org16dddf6" class="outline-2">
+<h2 id="org16dddf6"><span class="section-number-2">6.</span> How to convert from .md to .org</h2>
+<div class="outline-text-2" id="text-6">
+<div class="org-src-container">
+<pre class="src src-shell">find . -name \*.txt -type f -exec pandoc  -f markdown -t org -o {}.org {} \; 
+
+# For single file
+pandoc -f markdown -t org -o newfile.org original-file.markdown` - for single file
+</pre>
+</div>
+<ul class="org-ul">
+<li>Ref - <a href="https://emacs.stackexchange.com/questions/5465/how-to-migrate-markdown-files-to-emacs-org-mode-format?newreg=e7a7418622254c10bdeb95f048e3e151">https://emacs.stackexchange.com/questions/5465/how-to-migrate-markdown-files-to-emacs-org-mode-format?newreg=e7a7418622254c10bdeb95f048e3e151</a></li>
+</ul>
+</div>
+</section>
+
+<section id="outline-container-org749b84c" class="outline-2">
+<h2 id="org749b84c"><span class="section-number-2">7.</span> How to change escape key to other key in Archcraft</h2>
+<div class="outline-text-2" id="text-7">
+<p>
+Modify the file <code>~/usr/share/X11/xkb/keycodes/evdev</code>
+</p>
+<div class="org-src-container">
+<pre class="src src-conf">&lt;ESC&gt; = 95;
+</pre>
+</div>
+
+<p>
+Multiple code assigning to a keyname is not possible nut can be possible through scripts&#x2026; but below is better ways
+Add to <code>.bashrc</code> or <code>.zshrc</code> or <code>.profile</code> or whatever script runs first.
+</p>
+<div class="org-src-container">
+<pre class="src src-conf">xmodmap -e 'keycode 95=Escape'
+</pre>
+</div>
+
+<p>
+Ref - <a href="https://askubuntu.com/a/1070882">https://askubuntu.com/a/1070882</a>
+</p>
+</div>
+</section>
+
+<section id="outline-container-org5464ed3" class="outline-2">
+<h2 id="org5464ed3"><span class="section-number-2">8.</span> REVISION Unexpected crash shutdown in Archcraft</h2>
+<div class="outline-text-2" id="text-8">
+<dl class="org-dl">
+<dt>Systemd</dt><dd>Provides a system and service manager that runs as PID 1 &amp; starts the rest of the system.
+<ul class="org-ul">
+<li>Includes a logging daemon, utilities to control basic system configuration like hostname, date, locale.</li>
+<li>Maintains a list of logged-in users and running containers and virtual machines, system accounts, runtime dir and settings and daemons to manage simple network configuration, netword time resolution, log forwarding, and name resolution.</li>
+</ul></dd>
+<dt>systemctl</dt><dd>controls systemd daemons and service manager.</dd>
+</dl>
+</div>
+</section>
+
+<section id="outline-container-org063c312" class="outline-2">
+<h2 id="org063c312"><span class="section-number-2">9.</span> xbacklight not working in Archcraft</h2>
+<div class="outline-text-2" id="text-9">
+<p>
+Install <code>acpilight</code>  
+</p>
+
+<p>
+Ref - <a href="https://askubuntu.com/questions/715306/xbacklight-no-outputs-have-backlight-property-no-sys-class-backlight-folder">https://askubuntu.com/questions/715306/xbacklight-no-outputs-have-backlight-property-no-sys-class-backlight-folder</a>
+</p>
+</div>
+</section>
+
+<section id="outline-container-org82c7f50" class="outline-2">
+<h2 id="org82c7f50"><span class="section-number-2">10.</span> optimus-manager causing screen tearing in Archcraft</h2>
+<div class="outline-text-2" id="text-10">
+<p>
+Installing <code>optimus-manager</code> results in archcraft to screen tearing.
+</p>
+
+<ul class="org-ul">
+<li>Modify <code>/etc/X11/xorg.conf.d/10-optimus-manager.conf</code></li>
+</ul>
+<div class="org-src-container">
+<pre class="src src-conf">Section "Device"
+Identifier "intel"
+Driver "modesetting"
+BusID "PCI:0:2:0"
+Option "DRI" "3"
+Option "TearFree" "true"
+EndSection
+</pre>
+</div>
+
+<ul class="org-ul">
+<li>Modify <code>/etc/X11/xorg.conf.d/20-intel.conf</code></li>
+</ul>
+<div class="org-src-container">
+<pre class="src src-conf">Section "Device"
+Identifier "Intel Graphics"
+Driver "intel"
+Option "AccelMethod" "sna"
+Option "DRI" "3"
+Option "TearFree" "true"
+EndSection
+</pre>
+</div>
+
+<ul class="org-ul">
+<li><p>
+Modify <code>.config/bspwm/picom.conf</code>
+</p>
+<div class="org-src-container">
+<pre class="src src-conf">backend = "glx";
+</pre>
+</div></li>
+
+<li>Ref - <a href="https://www.youtube.com/watch?v=GWQh_DmDLKQ">https://www.youtube.com/watch?v=GWQh_DmDLKQ</a></li>
+</ul>
+</div>
+</section>
+
+<section id="outline-container-orgf19df07" class="outline-2">
+<h2 id="orgf19df07"><span class="section-number-2">11.</span> How to get temperature record in Archcraft</h2>
+<div class="outline-text-2" id="text-11">
+<p>
+<code>sensors</code> provides all the temperatures.
+</p>
+<pre class="example" id="org85b598c">
+coretemp-isa-0000
+Adapter: ISA adapter
+Package id 0:  +52.0°C  (high = +100.0°C, crit = +100.0°C)
+Core 0:        +45.0°C  (high = +100.0°C, crit = +100.0°C)
+Core 1:        +46.0°C  (high = +100.0°C, crit = +100.0°C)
+Core 2:        +47.0°C  (high = +100.0°C, crit = +100.0°C)
+Core 3:        +52.0°C  (high = +100.0°C, crit = +100.0°C)
+
+pch_cannonlake-virtual-0
+Adapter: Virtual device
+temp1:        +65.0°C
+
+BAT1-acpi-0
+Adapter: ACPI interface
+in0:          12.77 V
+curr1:         0.00 A
+
+iwlwifi_1-virtual-0
+Adapter: Virtual device
+temp1:        +44.0°C
+
+nvme-pci-0200
+Adapter: PCI adapter
+Composite:    +39.9°C  (low  = -20.1°C, high = +84.8°C)
+(crit = +89.8°C)
+
+acpitz-acpi-0
+Adapter: ACPI interface
+temp1:        +48.0°C  (crit = +100.0°C)
+</pre>
+
+<p>
+<code>for i in /sys/class/thermal/thermal_zone*; do echo "$i: $(&lt;$i/type)"; done</code>  
+</p>
+<pre class="example" id="orgb26baf0">
+/sys/class/thermal/thermal_zone0: acpitz
+/sys/class/thermal/thermal_zone1: pch_cannonlake
+/sys/class/thermal/thermal_zone2: iwlwifi_1
+/sys/class/thermal/thermal_zone3: x86_pkg_temp
+</pre>
+
+<p>
+<code>for i in /sys/class/hwmon/hwmon*/temp*_input; do echo "$(&lt;$(dirname $i)/name): $(cat ${i%_*}_label 2&gt;/dev/null || echo $(basename ${i%_*})) $(readlink -f $i)"; done</code>
+</p>
+<pre class="example" id="orgdaced62">
+acpitz: temp1 /sys/devices/virtual/thermal/thermal_zone0/hwmon1/temp1_input
+nvme: Composite /sys/devices/pci0000:00/0000:00:1d.0/0000:02:00.0/nvme/nvme0/hwmon3/temp1_input
+pch_cannonlake: temp1 /sys/devices/virtual/thermal/thermal_zone1/hwmon4/temp1n_input
+iwlwifi_1: temp1 /sys/devices/virtual/thermal/thermal_zone2/hwmon5/temp1_input
+coretemp: Package id 0 /sys/devices/platform/coretemp.0/hwmon/hwmon6/temp1_input
+coretemp: Core 0 /sys/devices/platform/coretemp.0/hwmon/hwmon6/temp2_input
+coretemp: Core 1 /sys/devices/platform/coretemp.0/hwmon/hwmon6/temp3_input
+coretemp: Core 2 /sys/devices/platform/coretemp.0/hwmon/hwmon6/temp4_input
+coretemp: Core 3 /sys/devices/platform/coretemp.0/hwmon/hwmon6/temp5_input
+</pre>
+</div>
+</section>
+
+<section id="outline-container-org4e6b644" class="outline-2">
+<h2 id="org4e6b644"><span class="section-number-2">12.</span> How to customize touchpad to work on firefox</h2>
+<div class="outline-text-2" id="text-12">
+<dl class="org-dl">
+<dt><code>xinput</code></dt><dd>List available input devices, query info, change input settings.</dd>
+<dt>libinput</dt><dd>Handle input devices, device detection, input even processing for wayland &amp; Xorg <code>x86-input-libinput</code> driver.</dd>
+<dt>libinput-gestures</dt><dd>configure trackpad gestures through <code>xdotool</code> and for wayland <code>wtype</code>.
+<ul class="org-ul">
+<li><code>libinput-gestures-setup start</code>
+<ul class="org-ul">
+<li>If unable to start <code>libinput-gestures failed to start as a desktop application.</code>
+<ul class="org-ul">
+<li><code>sudo gpasswd -a $USER input</code></li>
+</ul></li>
+<li><code>newgrp input</code>
+<dl class="org-dl">
+<dt>newgrp</dt><dd>The same person remains logged in and the current dir is unchanged, but calculations of access permission to files are performed with respect to the new ID.</dd>
+</dl></li>
+</ul></li>
+</ul></dd>
+</dl>
+<ul class="org-ul">
+<li>Copy the config <code>rsync -avP /etc/libinput-gestures.conf ~/.config/</code>  
+<ul class="org-ul">
+<li><p>
+Modify the file 
+</p>
+<div class="org-src-container">
+<pre class="src src-conf">gesture swipe right 3 xdotool key control+Tab
+gesture swipe left 3 xdotool key control+shift+Tab
+</pre>
+</div></li>
+</ul></li>
+</ul>
+</div>
+</section>
+
+<section id="outline-container-orgb03f23d" class="outline-2">
+<h2 id="orgb03f23d"><span class="section-number-2">13.</span> Security tools</h2>
+<div class="outline-text-2" id="text-13">
+<dl class="org-dl">
+<dt>lynis</dt><dd>Security auditing tool. Checks system and the software configuration.
+<ul class="org-ul">
+<li><code>lynis audit system -Q</code></li>
+<li id="Ref"><a href="https://cisofy.com/lynis/">https://cisofy.com/lynis/</a></li>
+</ul></dd>
+<dt>rkhunter</dt><dd>Checks machines for the presence of rootkits and other unwanted tools.
+<ul class="org-ul">
+<li><code>rkhunter --propupd</code> Updates file properties database.</li>
+<li><code>rkhunter --sk</code> run system check</li>
+</ul></dd>
+</dl>
+</div>
+</section>
+
+<section id="outline-container-org98cc8de" class="outline-2">
+<h2 id="org98cc8de"><span class="section-number-2">14.</span> Custom fan control in MSI GF63-thin 9SCXR</h2>
+<div class="outline-text-2" id="text-14">
+<dl class="org-dl">
+<dt>isw</dt><dd>Custom fan control modification for different msi laptop.</dd>
+<dt>(no term)</dt><dd><code>isw -b on</code> cooler booster on/off toggle.</dd>
+<dt>(no term)</dt><dd><code>/etc/isw.conf</code></dd>
+<dt>(no term)</dt><dd>Ref
+<ul class="org-ul">
+<li><a href="https://github.com/YoyPa/isw/wiki/How-to-configure-ec_sys-with-write_support=1">https://github.com/YoyPa/isw/wiki/How-to-configure-ec_sys-with-write_support=1</a></li>
+<li><a href="https://github.com/YoyPa/isw">https://github.com/YoyPa/isw</a></li>
+</ul></dd>
+</dl>
+</div>
+</section>
+
+<section id="outline-container-orgf37154e" class="outline-2">
+<h2 id="orgf37154e"><span class="section-number-2">15.</span> plocate and locate</h2>
+<div class="outline-text-2" id="text-15">
+<p>
+Find all the files on the system matching the given pattern.
+Similar to <code>mlocate</code> but faster.
+</p>
+
+<dl class="org-dl">
+<dt><code>updatedb</code></dt><dd>updates the files index from which plocate searches.</dd>
+<dt>(no term)</dt><dd><p>
+Modify <code>/etc/updatedb.conf</code> for specifing which file updatedb should not scan.
+</p>
+<pre class="example">
+PRUNEPATHS = "/afs /media /mnt /net /sfs /tmp"
+</pre></dd>
+<dt>(no term)</dt><dd><code>plocate --ignore-case --database path_for_custom_index_db file_name</code></dd>
+<dt>(no term)</dt><dd>Default db <code>/var/lib/plocate/plocate.db</code></dd>
+</dl>
+</div>
+</section>
+
+<section id="outline-container-orgb6a6823" class="outline-2">
+<h2 id="orgb6a6823"><span class="section-number-2">16.</span> How to toggle hide/unhide for an application through keyboard shortcut in bspwm inside Archcraft</h2>
+<div class="outline-text-2" id="text-16">
+<ul class="org-ul">
+<li>Create script <code>touch scratchpad.sh</code></li>
+<li>Change mode <code>chmod -x</code> to executable</li>
+<li><p>
+Modify <code>scratchpad.sh</code> 
+</p>
+<div class="org-src-container">
+<pre class="src src-shell">#!/usr/bin/zsh
+
+# Check if application name provided or not
+# -z returns true if $1 is empty
+# Run sh scratchpad.sh application_name
+# $0 contains scratchpad.sh $1 contains application_name
+if [ -z $1 ]; then
+echo "usage: $0 name_of_hidden_scratchpad_window"
+exit 1
+fi
+
+# Find all process id of the application_name
+# xdotool searches all the window in bspwm like window title, size, etc.
+# search for window with title, names, classes with regex pattern
+# Search the pid of the running application that has a visible window
+# xdotool search --class --onlyvisible application_name
+pids = $(xdotool search --class ${1})
+
+# Toggle hidden for every window of given pids
+# --flag hidden toggles hidden property
+for pid in $pids; do
+echo "Toggle $pid"
+bspc node $pid --flag hidden --to-desktop focused -f
+done 
+</pre>
+</div></li>
+<li><p>
+Modify sxhkdrc
+</p>
+<pre class="example">
+super + slash
+sh ~/scratchpad.sh application_name
+</pre></li>
+<li>Ref - <a href="https://wiki.archlinux.org/title/Bspwm">https://wiki.archlinux.org/title/Bspwm</a></li>
+</ul>
+</div>
+</section>
+
+<section id="outline-container-org24676aa" class="outline-2">
+<h2 id="org24676aa"><span class="section-number-2">17.</span> How to use rsync</h2>
+<div class="outline-text-2" id="text-17">
+<p>
+Remote &amp; local file copying tool.
+<code>rsync -avP from to</code> :: -a recursion &amp; preserve everything, -v verbose, -P progress
+</p>
+</div>
+</section>
+
+<section id="outline-container-orgfdf4f08" class="outline-2">
+<h2 id="orgfdf4f08"><span class="section-number-2">18.</span> How to modify drives status</h2>
+<div class="outline-text-2" id="text-18">
+<p>
+<code>udiskstool</code>
+</p>
+<ul class="org-ul">
+<li><code>unmount -v /dev/block_name</code></li>
+<li><code>power-off -b /dev/block_name</code></li>
+</ul>
+
+<p>
+<code>hdparm</code> :: get/set SATA/IDE (Integrate Drive Electronics, ATA ) parameter
+</p>
+<dl class="org-dl">
+<dt><code>-y /dev/block</code></dt><dd>force IDE into low power consumption (standby mode)</dd>
+<dt>-Y</dt><dd>force into lowest power mode</dd>
+<dt>-C</dt><dd>current power mode</dd>
+</dl>
+
+<p>
+<code>sync</code> sync chached writes to persistent storage
+</p>
+<ul class="org-ul">
+<li>flush all the buffers to disk. It will ensure that no data is lingering in ram.</li>
+</ul>
+
+<p>
+<code>gnome-disks</code> :: GUI util for disks
+</p>
+
+<p>
+Ref - <a href="https://askubuntu.com/questions/586657/is-there-any-way-to-turn-off-a-usb-hdd-manually">https://askubuntu.com/questions/586657/is-there-any-way-to-turn-off-a-usb-hdd-manually</a>
+</p>
+</div>
+</section>
+
+<section id="outline-container-orga2a65c0" class="outline-2">
+<h2 id="orga2a65c0"><span class="section-number-2">19.</span> IDE (Integrate Drive Electronics)</h2>
+<div class="outline-text-2" id="text-19">
+<p>
+Electronic interface standard that defines the connection between a bus on a computer&rsquo;s motherboard and the computer&rsquo;s disk storage devices.
+</p>
+</div>
+</section>
+
+<section id="outline-container-orgba5889f" class="outline-2">
+<h2 id="orgba5889f"><span class="section-number-2">20.</span> Sound and Video stopped after update of pipewire Archcraft</h2>
+<div class="outline-text-2" id="text-20">
+<p>
+Do not run pulseaudio and pipewire that lead to conflict.
+Solves by removing one the packages.
+</p>
+
+<dl class="org-dl">
+<dt><code>pactl</code></dt><dd>control a running pulseaudio sound server.
+<dl class="org-dl">
+<dt>info</dt><dd>check if pipewire is activated.</dd>
+<dt>(no term)</dt><dd><p>
+if active 
+</p>
+<pre class="example" id="orga28d21f">
+Server Name: PulseAudio (on PipeWire 0.3.53)
+</pre></dd>
+<dt>(no term)</dt><dd><p>
+otherwise
+</p>
+<pre class="example" id="org7d46bc1">
+PluseAudio
+</pre></dd>
+</dl></dd>
+<dt>(no term)</dt><dd>Ref - <a href="https://askubuntu.com/questions/1333404/how-to-replace-pulseaudio-with-pipewire-on-ubuntu-21-04">https://askubuntu.com/questions/1333404/how-to-replace-pulseaudio-with-pipewire-on-ubuntu-21-04</a></dd>
+
+<dt><code>systemctl --user mask pulseaudio</code></dt><dd>link these to <code>/dev/null</code>
+<ul class="org-ul">
+<li>prohibits all kinds of activation.</li>
+<li>mask temporarily until nxt reboot.</li>
+</ul></dd>
+<dt><code>aplay</code></dt><dd>arecord, cmd-line sound recorder and player for ALSA soundcard driver.
+<ul class="org-ul">
+<li><code>-l</code> list all soundcards and digital audio devices.</li>
+<li><code>-L</code> list all PCMs (pulse code modulation) defined.</li>
+</ul></dd>
+<dt><code>alsactl</code></dt><dd>advanced setting for ALSA soundcard drivcer. Controller for the card&rsquo;s feature.
+<ul class="org-ul">
+<li><code>init</code> initializes all devices to a default state. Returns code 99 if device not found.</li>
+</ul></dd>
+<dt><code>pulseaudio -k</code></dt><dd>restart pulseaudio</dd>
+<dt>(no term)</dt><dd>Ref
+<ul class="org-ul">
+<li><a href="https://bbs.archlinux.org/viewtopic.php?id=237364">https://bbs.archlinux.org/viewtopic.php?id=237364</a></li>
+<li><a href="https://wiki.archlinux.org/title/PipeWire">https://wiki.archlinux.org/title/PipeWire</a></li>
+<li><a href="https://ubuntuhandbook.org/index.php/2022/04/pipewire-replace-pulseaudio-ubuntu-2204/">https://ubuntuhandbook.org/index.php/2022/04/pipewire-replace-pulseaudio-ubuntu-2204/</a></li>
+</ul></dd>
+</dl>
+</div>
+</section>
+
+<section id="outline-container-orgedd2137" class="outline-2">
+<h2 id="orgedd2137"><span class="section-number-2">21.</span> wireplumber and pipewire-media-session are in conflict in Archcraft</h2>
+<div class="outline-text-2" id="text-21">
+<p>
+Audio and video all will stop being played.
+Just removes one of it.
+pipewire-media-session is simple session manager.
+While pipewire is multimedia framework.
+</p>
+</div>
+</section>
+
+<section id="outline-container-org68908a6" class="outline-2">
+<h2 id="org68908a6"><span class="section-number-2">22.</span> rfkill</h2>
+<div class="outline-text-2" id="text-22">
+<p>
+Tool for enabling/disabling wireless devices.
+<code>rfkill list</code> :: list all wireless device.
+</p>
+</div>
+</section>
+
+<section id="outline-container-org3401299" class="outline-2">
+<h2 id="org3401299"><span class="section-number-2">23.</span> failed to commit transaction (conflicting files)</h2>
+<div class="outline-text-2" id="text-23">
+<p>
+The problem will appear when some package are updated maually without using package manager like <code>npm update</code>.
+Pacman keeps track of installed package and by udpating manually a package, pacman get conflict.
+</p>
+</div>
+
+<div id="outline-container-orgb44b608" class="outline-3">
+<h3 id="orgb44b608"><span class="section-number-3">23.1.</span> Ignore the package which are creating problme</h3>
+<div class="outline-text-3" id="text-23-1">
+<p>
+<code>pacman -Syu --ignore=npm</code> :: udpate every pkg except &rsquo;npm&rsquo;
+<code>pacman -Syu --ignoregroup=plasma-desktop</code>
+</p>
+
+<p>
+Permanentally ignoring a package
+<code>/etc/pacman.conf</code>
+</p>
+<div class="org-src-container">
+<pre class="src src-conf">IgnorePkg=npm
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-org4954217" class="outline-3">
+<h3 id="org4954217"><span class="section-number-3">23.2.</span> Overwrite files</h3>
+<div class="outline-text-3" id="text-23-2">
+<p>
+<code>pacman -S pkg_name --overwrite '*'</code>
+</p>
+<dl class="org-dl">
+<dt><code>'*'</code></dt><dd>overwrites everyfile</dd>
+<dt><code>/path/to/*</code></dt><dd>a specific file</dd>
+</dl>
+</div>
+</div>
+
+<div id="outline-container-orgbec9caf" class="outline-3">
+<h3 id="orgbec9caf"><span class="section-number-3">23.3.</span> Check if any pkg owns the file</h3>
+<div class="outline-text-3" id="text-23-3">
+<ul class="org-ul">
+<li><code>pacman -Qo /path/to/file</code></li>
+<li>if identifies config pkg
+<ul class="org-ul">
+<li><code>pacman -R pkg</code></li>
+</ul></li>
+<li>if no pkg identifies it
+<ul class="org-ul">
+<li><code>rm /path/to/file</code> or move the file to backup if something get worng</li>
+</ul></li>
+</ul>
+</div>
+</div>
+</section>
+
+<section id="outline-container-orgc519084" class="outline-2">
+<h2 id="orgc519084"><span class="section-number-2">24.</span> Unhide a window in bspwm in Archcraft</h2>
+<div class="outline-text-2" id="text-24">
+<div class="org-src-container">
+<pre class="src src-shell"># Get a list of hidden window
+bspc query -N -n .hidden
+</pre>
+</div>
+<div class="org-src-container">
+<pre class="src src-shell">bspc node $(bspc quey -N -n .hidden | tail -n1) -g hidden=off)
+</pre>
+</div>
+</div>
+</section>
+
+<section id="outline-container-org5bef9ce" class="outline-2">
+<h2 id="org5bef9ce"><span class="section-number-2">25.</span> If pacman package got deleted</h2>
+<div class="outline-text-2" id="text-25">
+<p>
+Let say <code>/usr/share/fonts</code> got deleted
+</p>
+<div class="org-src-container">
+<pre class="src src-shell">pacman -Qqo /usr/share/fonts | sudo pacman -S -
+</pre>
+</div>
+<dl class="org-dl">
+<dt><code>Q</code></dt><dd>query the installed pkg</dd>
+<dt>q</dt><dd>dont print the pkg version, just name</dd>
+<dt>o</dt><dd>own get every pkg that has (or had) a file <code>/usr/share/fonts</code></dd>
+<dt>|</dt><dd>piping</dd>
+<dt>-S</dt><dd>install pkg</dd>
+<dt>-</dt><dd>a single dash tells pacman to read pkg list from stdin</dd>
+</dl>
+</div>
+</section>
+
+<section id="outline-container-orgccd8dde" class="outline-2">
+<h2 id="orgccd8dde"><span class="section-number-2">26.</span> duf (shows about the disk)</h2>
+</section>
+<section id="outline-container-orgd76165b" class="outline-2">
+<h2 id="orgd76165b"><span class="section-number-2">27.</span> Start xfce4-terminal in float mode in Archcraft</h2>
+<div class="outline-text-2" id="text-27">
+<p>
+<code>~/.config/bspwm/bspwmrc</code>
+</p>
+<div class="org-src-container">
+<pre class="src src-shell">bspc rule -a Xfce-teminal state=floating sticy-on
+# make sure application name starts with capital letter
+</pre>
+</div>
+<p>
+<code>/.config/sxhdkrc/sxhkdrc</code> 
+</p>
+<pre class="example">
+super + period
+xfce-terminal --drop-down
+</pre>
+<p>
+Edit xfce terminal setting to position it and other stuff.
+</p>
+
+<ul class="org-ul">
+<li><p>
+Does not work this way
+</p>
+<pre class="example">
+super + period
+bspc rule -a \* -o state=floating sticky=on
+</pre></li>
+<li>Ref
+<ul class="org-ul">
+<li><a href="https://github.com/kamranahmedse/pennywise">https://github.com/kamranahmedse/pennywise</a></li>
+<li><a href="https://fsylum.net/blog/setting-up-persistent-floating-browser-window-bspwm/">https://fsylum.net/blog/setting-up-persistent-floating-browser-window-bspwm/</a></li>
+</ul></li>
+</ul>
+</div>
+</section>
+
+<section id="outline-container-org4d9a297" class="outline-2">
+<h2 id="org4d9a297"><span class="section-number-2">28.</span> git error: unsafe repo</h2>
+<div class="outline-text-2" id="text-28">
+<blockquote>
+<p>
+fatal: Not a git repository (or any of the parent directories): .git
+</p>
+</blockquote>
+<blockquote>
+<p>
+Error: Command failed: git add -A
+fatal: unsafe repository (&rsquo;<i>mnt</i>&#x2026;&#x2026;.&rsquo; is owned by someone else)
+To add an exception for this directory, call:
+git config &#x2013;global &#x2013;add safe.directory <i>mnt</i>&#x2026;&#x2026;&#x2026;
+</p>
+</blockquote>
+
+<p>
+Git patch a vulnerablity which are exploiting shared memory location. Which is applicable on multi user machine.
+Ref
+</p>
+<ul class="org-ul">
+<li><a href="https://github.blog/2022-04-12-git-security-vulnerability-announced/">https://github.blog/2022-04-12-git-security-vulnerability-announced/</a></li>
+<li><a href="https://stackoverflow.com/questions/71901632/fatal-error-unsafe-repository-home-repon-is-owned-by-someone-else">https://stackoverflow.com/questions/71901632/fatal-error-unsafe-repository-home-repon-is-owned-by-someone-else</a></li>
+</ul>
+
+<p>
+<code>git config --global --add safe.directory dir_path</code>  
+</p>
+</div>
+</section>
+
+
+<section id="outline-container-org5cbe1c1" class="outline-2">
+<h2 id="org5cbe1c1"><span class="section-number-2">29.</span> Blank screen after boot in Archcraft</h2>
+<div class="outline-text-2" id="text-29">
+<pre class="example" id="org3275df3">
+running hook[udev]
+triggering uevents
+running hook [keymap]
+loading keymap... done
+running hook[plymouth]
+performing fsck on '/dev/nvme0n1p8'
+arch_root: recovering journal
+arch_root:clean, 472471/1966080 files, 4306229/7864320 blocks
+mounting '/dev/nvme0n1p8' on real root
+running cleanup hook [udev]
+ERROR: Root device mounted successfully, but /sbin/init does not exist.
+Bailing out, you are on your own. Good luck.
+sh:can't access tty; job control turned off
+[rootfs ]#
+</pre>
+</div>
+
+<div id="outline-container-org90e34b0" class="outline-3">
+<h3 id="org90e34b0"><span class="section-number-3">29.1.</span> Arch chroot sanatize it</h3>
+<div class="outline-text-3" id="text-29-1">
+<ul class="org-ul">
+<li>Create live usb and boot</li>
+<li>Get root partition of broken arch</li>
+<li><code>arch-chroot /mnt</code> into the system</li>
+<li><code>df -h</code> list all the system files by default
+<ul class="org-ul">
+<li>may have to edit symlink if required system file are in diff. dir.</li>
+</ul></li>
+<li><code>sudo pacman -Syyu</code></li>
+<li><code>ln -sf /usr/sbin/init /sbin/init</code>
+<ul class="org-ul">
+<li><code>sbin/init -&gt; ../lib/systemd/systemd</code> try to create this link</li>
+</ul></li>
+<li><code>mkinitcpio -p linux</code> create inital ramdisk env.
+<ul class="org-ul">
+<li><code>-p</code> according to specified preset located in <code>/etc/mkinitcpio.d</code></li>
+</ul></li>
+<li><code>locale-gen</code> generate locatlisation file</li>
+</ul>
+</div>
+</div>
+</section>
+
+<section id="outline-container-org59ea26b" class="outline-2">
+<h2 id="org59ea26b"><span class="section-number-2">30.</span> Additional monitor connection</h2>
+<div class="outline-text-2" id="text-30">
+<dl class="org-dl">
+<dt>xrandr</dt><dd>responsible for displaying stuff
+<ul class="org-ul">
+<li><code>xrandr --output "HDMI-2" --auto</code> start rendering on second monitor</li>
+</ul></dd>
+<dt>autorandr</dt><dd>automatically select a display config based on connected devices</dd>
+<dt>mons</dt><dd>manage 2 monitor display</dd>
+<dt>ARandR</dt><dd><p>
+for setting screen resolution
+<code>~/.config/sxhkd/sxhkdrc</code>  
+</p>
+<div class="org-src-container">
+<pre class="src src-conf">super + shift + {Prior, Next}
+bspc node -m {prev, next} --follow
+</pre>
+</div></dd>
+</dl>
+</div>
+</section>
+
+<section id="outline-container-orgc206664" class="outline-2">
+<h2 id="orgc206664"><span class="section-number-2">31.</span> xev</h2>
+<div class="outline-text-2" id="text-31">
+<p>
+Input device even listner
+</p>
+</div>
+</section>
+
+<section id="outline-container-orgfb7baef" class="outline-2">
+<h2 id="orgfb7baef"><span class="section-number-2">32.</span> change ls output color</h2>
+<div class="outline-text-2" id="text-32">
+<p>
+<code>LS_COLORS='ow=1;4;95:'</code>
+</p>
+<ul class="org-ul">
+<li>setting ow (other write permission) 1-bold, 4-underline, 95-lightpurple</li>
+<li>Print all <code>ls -color</code> config
+<ul class="org-ul">
+<li><code>dircolors</code></li>
+</ul></li>
+<li>Ref - <a href="https://askubuntu.com/questions/466198/how-do-i-change-the-color-for-directories-with-ls-in-the-console">https://askubuntu.com/questions/466198/how-do-i-change-the-color-for-directories-with-ls-in-the-console</a></li>
+<li><div class="org-src-container">
+<pre class="src src-ascii">| Code Color         | Code Color                    | StyleCode Style                                                |
+|--------------------+-------------------------------+----------------------------------------------------------------|
+| 31 = red          | 40 = black background        | 0 = default colour                                           |
+| 32 = green        | 41 = red background          | 1 = bold                                                     |
+| 33 = orange       | 42 = green background        | 4 = underlined                                               |
+| 34 = blue         | 43 = orange background       | 5 = flashing text                                            |
+| 35 = purple       | 44 = blue background         | 7 = reverse field (exchange foreground and background color) |
+| 36 = cyan         | 45 = purple background       | 8 = concealed (invisible)                                    |
+| 37 = grey         | 46 = cyan background         |                                                                |
+| 90 = dark grey    | 47 = grey background         |                                                                |
+| 91 = light red    | 100 = dark grey background    |                                                                |
+| 92 = light green  | 101 = light red background    |                                                                |
+| 93 = yellow       | 102 = light green background  |                                                                |
+| 94 = light blue   | 103 = yellow background       |                                                                |
+| 95 = light purple | 104 = light blue background   |                                                                |
+| 96 = turquoise    | 105 = light purple background |                                                                |
+| 97 = white        | 106 = turquoise background    |                                                                |
+|                    | 107 = white background        |                                                                |
+</pre>
+</div></li>
+</ul>
+</div>
+</section>
+
+
+
+
+
+<section id="outline-container-orgb0fca6b" class="outline-2">
+<h2 id="orgb0fca6b"><span class="section-number-2">33.</span> Setup RAG</h2>
+</section>
+ </template>

--- a/src/components/notes/publish/NtCpuArchitecture.vue
+++ b/src/components/notes/publish/NtCpuArchitecture.vue
@@ -1,0 +1,107 @@
+ <template>
+<div id="table-of-contents" role="doc-toc">
+<h2>Table of Contents</h2>
+<div id="text-table-of-contents" role="doc-toc">
+<ul>
+<li><a href="#orga8ab133">1. INSTRUCTION SET ARCHITECTURE ( ISA )</a>
+<ul>
+<li><a href="#org6892e2f">1.1. RISC (Reduced Instruction Set Computing)</a>
+<ul>
+<li><a href="#org678a340">Origins</a></li>
+<li><a href="#orgfc08864">Distribution</a></li>
+</ul>
+</li>
+<li><a href="#orgb0d4183">1.2. CISC (complex instrustion set computing)</a>
+<ul>
+<li><a href="#orgcbfbe10">ARM (closed source ISA)</a></li>
+</ul>
+</li>
+<li><a href="#orge753b9b">1.3. x86-64 (closed source ISA)</a></li>
+<li><a href="#org3482bcb">1.4. RISC-V market players</a></li>
+</ul>
+</li>
+</ul>
+</div>
+</div>
+
+<section id="outline-container-orga8ab133" class="outline-2">
+<h2 id="orga8ab133"><span class="section-number-2">1.</span> INSTRUCTION SET ARCHITECTURE ( ISA )</h2>
+<div class="outline-text-2" id="text-1">
+</div>
+<div id="outline-container-org6892e2f" class="outline-3">
+<h3 id="org6892e2f"><span class="section-number-3">1.1.</span> RISC (Reduced Instruction Set Computing)</h3>
+<div class="outline-text-3" id="text-1-1">
+<p>
+executes a large number of simple instruction to complete a task
+</p>
+</div>
+<div id="outline-container-org678a340" class="outline-4">
+<h4 id="org678a340">Origins</h4>
+<div class="outline-text-4" id="text-org678a340">
+<ul class="org-ul">
+<li>developed in Parallel Computing Laboratory at University of California Berkeley</li>
+<li>first ever RISC architecture was created in 1980 1984</li>
+<li>RISC-V is the 5 gen of Berkeley RISC</li>
+</ul>
+</div>
+</div>
+
+<div id="outline-container-orgfc08864" class="outline-4">
+<h4 id="orgfc08864">Distribution</h4>
+<div class="outline-text-4" id="text-orgfc08864">
+<ul class="org-ul">
+<li>distributing is free</li>
+<li>chip designer using RISC-V can choose not to disclose their IP(intellectual property) in public domain
+<ul class="org-ul">
+<li>so not all processor will be open hardware</li>
+</ul></li>
+<li>frelly extented HOW:
+<ul class="org-ul">
+<li>gives flexibility when creating custom processor</li>
+</ul></li>
+</ul>
+</div>
+</div>
+</div>
+
+<div id="outline-container-orgb0d4183" class="outline-3">
+<h3 id="orgb0d4183"><span class="section-number-3">1.2.</span> CISC (complex instrustion set computing)</h3>
+<div class="outline-text-3" id="text-1-2">
+<p>
+executes a smaller number of complex instrustion to complete a task
+</p>
+</div>
+<div id="outline-container-orgcbfbe10" class="outline-4">
+<h4 id="orgcbfbe10">ARM (closed source ISA)</h4>
+<div class="outline-text-4" id="text-orgcbfbe10">
+<ul class="org-ul">
+<li>used in android, iOS, apple M series chip&#x2026; distributed using paid licence fee.</li>
+</ul>
+</div>
+</div>
+</div>
+
+<div id="outline-container-orge753b9b" class="outline-3">
+<h3 id="orge753b9b"><span class="section-number-3">1.3.</span> x86-64 (closed source ISA)</h3>
+<div class="outline-text-3" id="text-1-3">
+<ul class="org-ul">
+<li>used in desktop, laptops, servers&#x2026; created by Intel &amp; extented x86-64 by AMD&#x2026; both have the licence to distribute it.</li>
+</ul>
+</div>
+</div>
+
+<div id="outline-container-org3482bcb" class="outline-3">
+<h3 id="org3482bcb"><span class="section-number-3">1.4.</span> RISC-V market players</h3>
+<div class="outline-text-3" id="text-1-4">
+<p>
+risc-v international is a nonprofit association created for making it accessable
+</p>
+<ul class="org-ul">
+<li>2000 members - google,intel, nvidia,arduino, qualcomm,samsung</li>
+<li>SiFive- dev RISC-V processor</li>
+<li>t-head - from alibaba</li>
+</ul>
+</div>
+</div>
+</section>
+ </template>

--- a/src/components/notes/publish/NtLinux.vue
+++ b/src/components/notes/publish/NtLinux.vue
@@ -1,0 +1,1982 @@
+ <template>
+<div id="table-of-contents" role="doc-toc">
+<h2>Table of Contents</h2>
+<div id="text-table-of-contents" role="doc-toc">
+<ul>
+<li><a href="#orgb1a6a93">1. Resources</a></li>
+<li><a href="#org9602f0c">2. Shell scripting</a>
+<ul>
+<li><a href="#orgccb2647">2.1. Creating shell script</a></li>
+<li><a href="#org0981717">2.2. Define variable</a></li>
+<li><a href="#orgd7bd679">2.3. Arithematic expression</a></li>
+<li><a href="#org716bb79">2.4. Read user input</a></li>
+<li><a href="#orgc0f786b">2.5. Numeric comparision logical operator</a></li>
+<li><a href="#org5622bcf">2.6. Conditional</a></li>
+<li><a href="#org40fde31">2.7. Looping</a></li>
+<li><a href="#orgcb415a8">2.8. Reading files</a></li>
+<li><a href="#org054d759">2.9. Execute commands inside script using backticks</a></li>
+<li><a href="#orga8f2fa6">2.10. Get argument from command line</a></li>
+<li><a href="#orga7bc68e">2.11. Automate scripts by scheduling via cron jobs</a></li>
+<li><a href="#org072760d">2.12. Environment</a></li>
+<li><a href="#org83ac826">2.13. Text manipulation</a></li>
+</ul>
+</li>
+<li><a href="#org5324dcb">3. System administration</a>
+<ul>
+<li><a href="#orge8a4364">3.1. Essential Duties</a></li>
+<li><a href="#org8047904">3.2. <code>groupadd</code></a></li>
+<li><a href="#org880e6e5">3.3. <code>useradd</code></a></li>
+<li><a href="#org8399c95">3.4. <code>usermod</code></a></li>
+<li><a href="#org60e214b">3.5. <code>userdel</code></a></li>
+<li><a href="#orge56eb80">3.6. Administrative priviledges</a></li>
+<li><a href="#orgd06cb78">3.7. Shutdown process</a></li>
+</ul>
+</li>
+<li><a href="#org543178c">4. Basics</a>
+<ul>
+<li><a href="#org0e94844">4.1. Inode number</a></li>
+<li><a href="#org6a7e94c">4.2. Link</a></li>
+<li><a href="#orge4aca93">4.3. History</a></li>
+<li><a href="#org3cb5c16">4.4. Cmds</a></li>
+<li><a href="#org397c663">4.5. Init</a></li>
+<li><a href="#org23b8c79">4.6. Devices</a></li>
+<li><a href="#orgbf180b5">4.7. Files</a></li>
+<li><a href="#orgda22df2">4.8. Permission</a></li>
+</ul>
+</li>
+<li><a href="#org90e82a6">5. Again setting up linux</a>
+<ul>
+<li><a href="#org424217f">5.1. Important thing to remember</a></li>
+<li><a href="#orgb32684a">5.2. Partitioning</a></li>
+</ul>
+</li>
+<li><a href="#orgb8b226b">6. Linux startup proces</a>
+<ul>
+<li><a href="#org0e197d8">6.1. Power on</a></li>
+<li><a href="#org0f945ac">6.2. BIOS/UEFI</a>
+<ul>
+<li><a href="#orgdff63ef">BIOS (Basic input output system)</a></li>
+<li><a href="#org5c78de0">UEFI (Universal Extensible Firmware Interface)</a></li>
+<li><a href="#orga1eb2a4">Know the system</a></li>
+</ul>
+</li>
+<li><a href="#org24f84e2">6.3. MBR/EFI</a></li>
+<li><a href="#org1a575b4">6.4. Boot Loader</a></li>
+<li><a href="#org239340d">6.5. Kernel</a></li>
+<li><a href="#org1f80eb5">6.6. Initramfs</a></li>
+<li><a href="#org7c45537">6.7. /sbin/init (parent process)</a></li>
+<li><a href="#orga56acef">6.8. commmand shel using getty</a></li>
+<li><a href="#orgf6de0b0">6.9. GUI (Xwindow or Wayland)</a></li>
+</ul>
+</li>
+<li><a href="#org4be9c3d">7. Systemd</a></li>
+<li><a href="#orgd935de7">8. Man page</a></li>
+<li><a href="#org5243a6b">9. Laptop fan configuration</a></li>
+<li><a href="#orgb27c87c">10. Command Categorization</a>
+<ul>
+<li><a href="#org3f96a68">10.1. Search</a></li>
+<li><a href="#orgdd32aca">10.2. Networking</a></li>
+<li><a href="#org9ef572d">10.3. About System</a></li>
+<li><a href="#org1817515">10.4. Systemd</a></li>
+<li><a href="#org621836d">10.5. Configure system</a></li>
+<li><a href="#org13bcaa7">10.6. File</a></li>
+<li><a href="#org9cf1125">10.7. User</a></li>
+<li><a href="#org500018c">10.8. Security Research</a></li>
+<li><a href="#org4456ae4">10.9. Filteration</a></li>
+<li><a href="#org5a9d87d">10.10. Environment Varibale</a></li>
+<li><a href="#org8a353e0">10.11. Compression &amp; Decompression</a></li>
+</ul>
+</li>
+<li><a href="#org4a01bd1">11. <code>mime ^text,  label editor = ${VISUAL:-$EDITOR} -- "$@"</code></a></li>
+<li><a href="#org8d1518f">12. Compression vs Archieving</a></li>
+<li><a href="#org30977ca">13. ACTIVE OverTheWire</a>
+<ul>
+<li><a href="#orga6e4b68">13.1. Level code</a>
+<ul>
+<li><a href="#org5ea225a">14 (Using ssh to connect)</a></li>
+<li><a href="#orgbff6122">15 (Connecting to localhost on port 30000)</a></li>
+<li><a href="#orga24b56c">16 (Conneting to localhost on port 30001 through SSL)</a></li>
+<li><a href="#org523b27e">17 (Finding the correct SSL port)</a></li>
+</ul>
+</li>
+<li><a href="#org9c535b6">13.2. Base64</a></li>
+<li><a href="#org3069c54">13.3. ssh (Secure shell)</a></li>
+</ul>
+</li>
+<li><a href="#orgd089d95">14. OpenSSL</a>
+<ul>
+<li><a href="#org6b50200">14.1. Encrypting a Message with a Password</a></li>
+<li><a href="#org55f2d3d">14.2. Decrypting a Message with a Password</a></li>
+<li><a href="#org1e92c72">14.3. Encrypting a file with a Password</a></li>
+</ul>
+</li>
+<li><a href="#org20ee203">15. Filesystem</a></li>
+<li><a href="#orgf8118d8">16. SELinux (Security Enhanced Linux)</a></li>
+<li><a href="#org116b95a">17. Structure of Linux</a></li>
+<li><a href="#orgba2c5ab">18. heyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy</a></li>
+</ul>
+</div>
+</div>
+
+
+<section id="outline-container-orgb1a6a93" class="outline-2">
+<h2 id="orgb1a6a93"><span class="section-number-2">1.</span> Resources</h2>
+<div class="outline-text-2" id="text-1">
+<p>
+Syllabus type website on linux
+</p>
+<table>
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<thead>
+<tr>
+<th scope="col" class="org-left">Desc</th>
+<th scope="col" class="org-left">Link</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="org-left">Validating shell scripting</td>
+<td class="org-left"><a href="https://www.shellcheck.net/">https://www.shellcheck.net/</a></td>
+</tr>
+
+<tr>
+<td class="org-left">Deep dive into linux by IBM</td>
+<td class="org-left"><a href="https://developer.ibm.com/tutorials/l-lpic1-map/#exam-101-topic-101-system-architecture2">https://developer.ibm.com/tutorials/l-lpic1-map/#exam-101-topic-101-system-architecture2</a></td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left"><a href="https://developer.ibm.com/technologies/linux/">https://developer.ibm.com/technologies/linux/</a></td>
+</tr>
+
+<tr>
+<td class="org-left">Detailed but old (provides multiple format to study incl. pdf)</td>
+<td class="org-left"><a href="https://tldp.org/LDP/tlk/tlk.html">https://tldp.org/LDP/tlk/tlk.html</a></td>
+</tr>
+
+<tr>
+<td class="org-left">Kernel Development</td>
+<td class="org-left"><a href="https://www.kernel.org/doc/html/latest/">https://www.kernel.org/doc/html/latest/</a></td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left"><a href="https://linux-kernel-labs.github.io/refs/heads/master/index.html">https://linux-kernel-labs.github.io/refs/heads/master/index.html</a></td>
+</tr>
+</tbody>
+</table>
+
+<p>
+Blogs/Article on linux specific topics
+</p>
+<table>
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<thead>
+<tr>
+<th scope="col" class="org-left">Topic</th>
+<th scope="col" class="org-left">Desc</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="org-left">Structure of linux</td>
+<td class="org-left"><a href="https://developer.ibm.com/articles/l-linux-kernel/">https://developer.ibm.com/articles/l-linux-kernel/</a></td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left"><a href="https://en.wikibooks.org/wiki/Linux_Basics/The_structure_of_Linux">https://en.wikibooks.org/wiki/Linux_Basics/The_structure_of_Linux</a></td>
+</tr>
+
+<tr>
+<td class="org-left">Filesystem</td>
+<td class="org-left"><a href="https://www.linuxfoundation.org/blog/blog/classic-sysadmin-the-linux-filesystem-explained">https://www.linuxfoundation.org/blog/blog/classic-sysadmin-the-linux-filesystem-explained</a></td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left"><a href="https://opensource.com/life/16/10/introduction-linux-filesystems">https://opensource.com/life/16/10/introduction-linux-filesystems</a></td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+</tbody>
+</table>
+
+<p>
+Books/Pdfs
+</p>
+<table>
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<thead>
+<tr>
+<th scope="col" class="org-left">Name</th>
+<th scope="col" class="org-left">Author</th>
+<th scope="col" class="org-left">Desc</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="org-left">The linux bible</td>
+<td class="org-left">Christopher Negus</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">RedHat Deployment guide</td>
+<td class="org-left">Red hat</td>
+<td class="org-left">Teachs you to the end point of any topic</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+</tbody>
+</table>
+
+<p>
+Online Challenges
+</p>
+<table>
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<thead>
+<tr>
+<th scope="col" class="org-left">Site</th>
+<th scope="col" class="org-left">Support</th>
+<th scope="col" class="org-left">Desc</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="org-left"><a href="http://eudyptula-challenge.org/">http://eudyptula-challenge.org/</a></td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Kernel development challenge, which is not active</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left"><a href="https://github.com/agelastic/eudyptula">https://github.com/agelastic/eudyptula</a></td>
+<td class="org-left">Someone posted the challenge on github archieve</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left"><a href="https://git.kernel.org/">https://git.kernel.org/</a></td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left"><a href="https://kernelnewbies.org/">https://kernelnewbies.org/</a></td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Kernel dev incl. tutorial</td>
+</tr>
+
+<tr>
+<td class="org-left"><a href="https://linuxupskillchallenge.com/">https://linuxupskillchallenge.com/</a></td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Guide to become sys admin&#x2026; start from server to conf.</td>
+</tr>
+
+<tr>
+<td class="org-left"><a href="https://lwn.net/Kernel/LDD3/">https://lwn.net/Kernel/LDD3/</a></td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Kernel driver book</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+</tbody>
+</table>
+</div>
+</section>
+
+<section id="outline-container-org9602f0c" class="outline-2">
+<h2 id="org9602f0c"><span class="section-number-2">2.</span> Shell scripting</h2>
+<div class="outline-text-2" id="text-2">
+</div>
+<div id="outline-container-orgccb2647" class="outline-3">
+<h3 id="orgccb2647"><span class="section-number-3">2.1.</span> Creating shell script</h3>
+<div class="outline-text-3" id="text-2-1">
+<div class="org-src-container">
+<pre class="src src-shell"># Create a shell script file.
+touch script.sh 
+
+# Find where bin file of program is located
+which bash
+
+# Provide execution permission
+chmod u+x script.sh
+</pre>
+</div>
+
+<p>
+<code>~/script.sh</code> 
+</p>
+<div class="org-src-container">
+<pre class="src src-shell"># Shebang, to let pc know to execute it via bash shell
+#! usr/bin/bash
+
+echo "Output from script"
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-org0981717" class="outline-3">
+<h3 id="org0981717"><span class="section-number-3">2.2.</span> Define variable</h3>
+<div class="outline-text-3" id="text-2-2">
+<div class="org-src-container">
+<pre class="src src-shell">var=value
+echo $var
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-orgd7bd679" class="outline-3">
+<h3 id="orgd7bd679"><span class="section-number-3">2.3.</span> Arithematic expression</h3>
+<div class="outline-text-3" id="text-2-3">
+<p>
+<code>+ - * / ** %</code>
+</p>
+<div class="org-src-container">
+<pre class="src src-shell">var=$((expression))
+</pre>
+</div>
+<div class="org-src-container">
+<pre class="src src-shell">echo "scale=2;22/7" | bc
+# bc is a calculator and scale=2 defines the upto decimal point 
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-org716bb79" class="outline-3">
+<h3 id="org716bb79"><span class="section-number-3">2.4.</span> Read user input</h3>
+<div class="outline-text-3" id="text-2-4">
+<div class="org-src-container">
+<pre class="src src-shell">read -p "Prompt for user input" var_name
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-orgc0f786b" class="outline-3">
+<h3 id="orgc0f786b"><span class="section-number-3">2.5.</span> Numeric comparision logical operator</h3>
+<div class="outline-text-3" id="text-2-5">
+<div class="org-src-container">
+<pre class="src src-shell">-eq # equal
+-gt # greater than
+-ge # greater than equal to
+-lt # less than 
+-le # less than equal to
+-ne # not equal to 
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-org5622bcf" class="outline-3">
+<h3 id="org5622bcf"><span class="section-number-3">2.6.</span> Conditional</h3>
+<div class="outline-text-3" id="text-2-6">
+<div class="org-src-container">
+<pre class="src src-shell">if [[conditional]]
+then
+statement
+elif [[$a -gt 40 -a $b -lt 6 ]]; then # AND condition
+statement
+elif [[$a -gt 40 -o $b -lt 6 ]]; then # OR condition
+else
+do
+statement
+fi
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-org40fde31" class="outline-3">
+<h3 id="org40fde31"><span class="section-number-3">2.7.</span> Looping</h3>
+<div class="outline-text-3" id="text-2-7">
+<div class="org-src-container">
+<pre class="src src-shell"># Looping with numbers
+for i in {1..5} 
+
+# Looping with string
+for x in text1 text2 text3
+
+# While
+i=1
+while [[$i -le 10]] ; do
+echo "$i"
+((i+=1))
+done
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-orgcb415a8" class="outline-3">
+<h3 id="orgcb415a8"><span class="section-number-3">2.8.</span> Reading files</h3>
+<div class="outline-text-3" id="text-2-8">
+<div class="org-src-container">
+<pre class="src src-shell">LINE=1
+while read -r CURRENT_LINE
+do
+echo "$LINE: $CURRENT_LINE"
+((LINE++))
+done &lt; "sample_file.txt"
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-org054d759" class="outline-3">
+<h3 id="org054d759"><span class="section-number-3">2.9.</span> Execute commands inside script using backticks</h3>
+<div class="outline-text-3" id="text-2-9">
+<div class="org-src-container">
+<pre class="src src-shell">var=`df -h | grep tmpfs`
+echo $var
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-orga8f2fa6" class="outline-3">
+<h3 id="orga8f2fa6"><span class="section-number-3">2.10.</span> Get argument from command line</h3>
+<div class="outline-text-3" id="text-2-10">
+<div class="org-src-container">
+<pre class="src src-shell">for x in $@ # $@ - position of the param starting from 1 
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-orga7bc68e" class="outline-3">
+<h3 id="orga7bc68e"><span class="section-number-3">2.11.</span> Automate scripts by scheduling via cron jobs</h3>
+<div class="outline-text-3" id="text-2-11">
+<div class="org-src-container">
+<pre class="src src-shell"># * repr minute hour day month weekday (s) 
+* * * * * sh /path/to/script.sh
+5 0 * 8 * sh script.sh # schedule at 00:05 in august
+0 22 ** 1-5 sh script.sh # schedule at 22:00 on every day-of-week from mon to fri
+crontab -l # list of scheduled scripts for a particular user 
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-org072760d" class="outline-3">
+<h3 id="org072760d"><span class="section-number-3">2.12.</span> Environment</h3>
+<div class="outline-text-3" id="text-2-12">
+<p>
+<code>env</code> :: list all environment variables
+<code>$PATH</code> :: where system looks for binaries for cmds 
+</p>
+</div>
+</div>
+
+<div id="outline-container-org83ac826" class="outline-3">
+<h3 id="org83ac826"><span class="section-number-3">2.13.</span> Text manipulation</h3>
+<div class="outline-text-3" id="text-2-13">
+<dl class="org-dl">
+<dt><code>&lt;</code> <code>&gt;</code></dt><dd>Redirection operator.</dd>
+<dt><code>ls &gt; file</code></dt><dd>stdout to the file.</dd>
+<dt><code>&lt; file</code></dt><dd>Output the file content into stdin.</dd>
+<dt><code>ls /folder_that_not_exists &gt; file</code></dt><dd>Outputs an error to terminal but not to the file</dd>
+<dt><code>0</code> stdin, <code>1</code> stdout, <code>2</code> stderr</dt><dd>Descriptor used to access file or streams
+<dl class="org-dl">
+<dt>access <b>stderr</b></dt><dd><code>ls /folder_that_not_exists 2&gt; file</code></dd>
+<dt>access both <b>stdout</b> &amp; <b>stdin</b></dt><dd><code>ls /folder_that_not_exists &amp;&gt; file</code> or <code>&amp;&gt; file</code></dd>
+<dt>delete <b>stderr</b> msg</dt><dd><code>ls /folder_that_not_exits &gt; /dev/null</code></dd>
+</dl></dd>
+<dt>cut :: prints seleted parts of line, <code>paste --serial file1 file2</code></dt><dd>show combined text file.</dd>
+<dt><code>head --line 15 file</code></dt><dd>Get first 15 lines from file, <code>tail</code> .</dd>
+<dt>(no term)</dt><dd><code>expand</code> and <code>unexpand</code></dd>
+<dt><code>join</code></dt><dd>join 2 files with common column
+<dl class="org-dl">
+<dt><code>join -1 1 -2 2 file1 file2</code></dt><dd>-1 from file , 1 common column</dd>
+</dl></dd>
+</dl>
+</div>
+</div>
+</section>
+
+<section id="outline-container-org5324dcb" class="outline-2">
+<h2 id="org5324dcb"><span class="section-number-2">3.</span> System administration</h2>
+<div class="outline-text-2" id="text-3">
+</div>
+<div id="outline-container-orge8a4364" class="outline-3">
+<h3 id="orge8a4364"><span class="section-number-3">3.1.</span> Essential Duties</h3>
+<div class="outline-text-3" id="text-3-1">
+<dl class="org-dl">
+<dt>Controlling Accesss</dt><dd>Create a/c of new user &amp; managing permissions.</dd>
+<dt>Adding Hardware</dt><dd>Install &amp; configuration.</dd>
+<dt>(no term)</dt><dd>Automating tasks</dd>
+<dt>Overseeing Backups</dt><dd>Backing up &amp; restoring timely.</dd>
+<dt>(no term)</dt><dd>Installing &amp; Upgrading Software</dd>
+<dt>Monitoring</dt><dd>Collecting &amp; analyzing log files. Keeps eyes on server disk space.</dd>
+<dt>(no term)</dt><dd>Troubleshooting</dd>
+<dt>(no term)</dt><dd>Maintaining local document</dd>
+<dt>(no term)</dt><dd>Monitoring Security</dd>
+<dt>(no term)</dt><dd>Tuning Performance</dd>
+<dt>(no term)</dt><dd>Developing site policy</dd>
+<dt>(no term)</dt><dd>FireFighting</dd>
+</dl>
+</div>
+</div>
+
+<div id="outline-container-org8047904" class="outline-3">
+<h3 id="org8047904"><span class="section-number-3">3.2.</span> <code>groupadd</code></h3>
+<div class="outline-text-3" id="text-3-2">
+<div class="org-src-container">
+<pre class="src src-shell">groupadd --gid groupdID group_name
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-org880e6e5" class="outline-3">
+<h3 id="org880e6e5"><span class="section-number-3">3.3.</span> <code>useradd</code></h3>
+<div class="outline-text-3" id="text-3-3">
+<div class="org-src-container">
+<pre class="src src-shell">useradd -u userId -g group_no -d user_login_dir -s user_login_shell -M name_of_user
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-org8399c95" class="outline-3">
+<h3 id="org8399c95"><span class="section-number-3">3.4.</span> <code>usermod</code></h3>
+<div class="outline-text-3" id="text-3-4">
+<div class="org-src-container">
+<pre class="src src-shell">usermod --comment     add comment for user account
+--home        modify dir of user a/c
+--expiredate  disable a/c on yyyy-mm-dd
+--gid         change primary group of user
+--groups      list of extra groups
+--append    add user to supplimentry groups, works with --groups only
+--login       change login name
+--lock        lock user password
+--move-home   move home dir to new dir
+--password    weird
+--shell       create a specific shell for new a/c
+--uid         assign uid 0-999
+--unlock      removes users password
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-org60e214b" class="outline-3">
+<h3 id="org60e214b"><span class="section-number-3">3.5.</span> <code>userdel</code></h3>
+<div class="outline-text-3" id="text-3-5">
+<div class="org-src-container">
+<pre class="src src-shell">userdel user_name
+</pre>
+</div>
+<p>
+User home dir and mail spool dir do not get deleted.
+<code>-r</code> :: remove home dir
+</p>
+<ul class="org-ul">
+<li>If user is logged in
+<ul class="org-ul">
+<li>log them out</li>
+<li>kill all the process <code>kill all -u user_name</code></li>
+<li>delete user <code>userdel -f user_name</code></li>
+</ul></li>
+</ul>
+</div>
+</div>
+
+<div id="outline-container-orge56eb80" class="outline-3">
+<h3 id="orge56eb80"><span class="section-number-3">3.6.</span> Administrative priviledges</h3>
+<div class="outline-text-3" id="text-3-6">
+<dl class="org-dl">
+<dt><code>wall</code></dt><dd>write message to all user</dd>
+<dt>date</dt><dd></dd>
+
+<dt>ulimit</dt><dd>set limitation on max files size the user can have</dd>
+<dt>(no term)</dt><dd>controlling use of <code>ar</code> &amp; <code>cron</code></dd>
+<dt>(no term)</dt><dd>maintain security password</dd>
+</dl>
+</div>
+</div>
+
+<div id="outline-container-orgd06cb78" class="outline-3">
+<h3 id="orgd06cb78"><span class="section-number-3">3.7.</span> Shutdown process</h3>
+<div class="outline-text-3" id="text-3-7">
+<ul class="org-ul">
+<li>Notify all user through <code>wall</code></li>
+<li>Send signal to all running processes so they will terminate normally.</li>
+<li>Log users off &amp; kill remaining processes.</li>
+<li>Unmount all secondary system.</li>
+<li>Write info about the file system status to disk.</li>
+</ul>
+</div>
+</div>
+</section>
+<section id="outline-container-org543178c" class="outline-2">
+<h2 id="org543178c"><span class="section-number-2">4.</span> Basics</h2>
+<div class="outline-text-2" id="text-4">
+</div>
+<div id="outline-container-org0e94844" class="outline-3">
+<h3 id="org0e94844"><span class="section-number-3">4.1.</span> Inode number</h3>
+<div class="outline-text-3" id="text-4-1">
+<p>
+<code>ls -i file</code> :: list file with inode no.
+assigned to a file / folder with details stored in inode table.
+</p>
+
+<p>
+Info that are covered
+</p>
+<ul class="org-ul">
+<li>owner of file</li>
+<li>group to owner belongs</li>
+<li>type of file</li>
+<li>file access permission</li>
+<li>date/time last accessed</li>
+<li>date/time last modified</li>
+<li>no. of links to the file</li>
+<li>size of file</li>
+<li>pointer to the block storing file&rsquo;s content</li>
+</ul>
+</div>
+</div>
+
+<div id="outline-container-org6a7e94c" class="outline-3">
+<h3 id="org6a7e94c"><span class="section-number-3">4.2.</span> Link</h3>
+<div class="outline-text-3" id="text-4-2">
+<p>
+<code>ln [option] target link_name</code>
+</p>
+
+<ul class="org-ul">
+<li><b>Hard links</b>
+<ul class="org-ul">
+<li>same inode value</li>
+<li>no extra space</li>
+<li>fast accesibility</li>
+<li>only on file no dir</li>
+<li>delete original &amp; still accessible</li>
+</ul></li>
+<li><b>Soft links</b>
+<ul class="org-ul">
+<li>path to original file</li>
+<li>extra space</li>
+<li>delete original &amp; its not accessible anymore</li>
+<li>applied to file &amp; dir</li>
+</ul></li>
+</ul>
+</div>
+</div>
+
+<div id="outline-container-orge4aca93" class="outline-3">
+<h3 id="orge4aca93"><span class="section-number-3">4.3.</span> History</h3>
+<div class="outline-text-3" id="text-4-3">
+<dl class="org-dl">
+<dt>1969</dt><dd>Unix by Ken Thompson</dd>
+<dt>1991</dt><dd>Linux by Linux Torvald</dd>
+</dl>
+</div>
+</div>
+
+<div id="outline-container-org3cb5c16" class="outline-3">
+<h3 id="org3cb5c16"><span class="section-number-3">4.4.</span> Cmds</h3>
+<div class="outline-text-3" id="text-4-4">
+<div class="org-src-container">
+<pre class="src src-shell">date
+whoami
+echo $SHELL
+pwd
+cd . (current dir) ..(previous dir) ~ (home) /(root
+ls
+Output - 
+{d/l(dir/link)r(read)w(write)x(execute)}user{r-(no_permission)-}group{r--}others no._of_links owner owner_grp file_size last_modification dir_name
+clear
+less file
+find
+file file
+history
+touch
+cat &gt; text.txt
+mkdri -p(recurssive) dir/dir/dir
+rm -r(recurssive) file
+rmdir -p dir_name/dir/dir
+cp -i(prompt) srouce destination
+-p(preserve mode,ownershipe, timestamp) 
+-r(dir recurssively)
+-v
+mv
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-org397c663" class="outline-3">
+<h3 id="org397c663"><span class="section-number-3">4.5.</span> Init</h3>
+</div>
+<div id="outline-container-org23b8c79" class="outline-3">
+<h3 id="org23b8c79"><span class="section-number-3">4.6.</span> Devices</h3>
+</div>
+<div id="outline-container-orgbf180b5" class="outline-3">
+<h3 id="orgbf180b5"><span class="section-number-3">4.7.</span> Files</h3>
+</div>
+<div id="outline-container-orgda22df2" class="outline-3">
+<h3 id="orgda22df2"><span class="section-number-3">4.8.</span> Permission</h3>
+</div>
+</section>
+<section id="outline-container-org90e82a6" class="outline-2">
+<h2 id="org90e82a6"><span class="section-number-2">5.</span> Again setting up linux</h2>
+<div class="outline-text-2" id="text-5">
+</div>
+<div id="outline-container-org424217f" class="outline-3">
+<h3 id="org424217f"><span class="section-number-3">5.1.</span> Important thing to remember</h3>
+<div class="outline-text-3" id="text-5-1">
+<ul class="org-ul">
+<li>Always have a <b>booted pendrive</b> of the <b>OS</b> because system can break anytime.</li>
+<li>Keep the <b>personal files / important files</b> in separate partition because once its lost it&rsquo;s lost foreever (<i>unless you do data recovery</i>).</li>
+<li>Backup <b>config files</b>.</li>
+<li>Never break <b>initramfs</b>, hard to find solution for it.</li>
+<li>Never stops/disconnet in between any type of update.</li>
+<li>Remember to write commands because theres a lot.</li>
+<li><b>man commands</b> before using anything, read about it.</li>
+</ul>
+</div>
+</div>
+
+<div id="outline-container-orgb32684a" class="outline-3">
+<h3 id="orgb32684a"><span class="section-number-3">5.2.</span> Partitioning</h3>
+<div class="outline-text-3" id="text-5-2">
+<ul class="org-ul">
+<li>efi    (/boot/esp)    (fat32)    512MB - 1GB (if planning to install multiple OS)</li>
+<li>/      (root)         (ext4)     30GB  - more</li>
+<li>~      (home)         (ext4)     40GB  - 60GB</li>
+<li>swap                             2GB   - RAM+2</li>
+<li>file   (/mnt/personal)(ntfs)     10GB  - more (keep the important files in different partition)</li>
+</ul>
+</div>
+</div>
+</section>
+
+<section id="outline-container-orgb8b226b" class="outline-2">
+<h2 id="orgb8b226b"><span class="section-number-2">6.</span> Linux startup proces</h2>
+<div class="outline-text-2" id="text-6">
+</div>
+<div id="outline-container-org0e197d8" class="outline-3">
+<h3 id="org0e197d8"><span class="section-number-3">6.1.</span> Power on</h3>
+</div>
+<div id="outline-container-org0f945ac" class="outline-3">
+<h3 id="org0f945ac"><span class="section-number-3">6.2.</span> BIOS/UEFI</h3>
+<div class="outline-text-3" id="text-6-2">
+<p>
+Initialize the hardware &amp; test them at starup.
+</p>
+</div>
+
+<div id="outline-container-orgdff63ef" class="outline-4">
+<h4 id="orgdff63ef">BIOS (Basic input output system)</h4>
+<div class="outline-text-4" id="text-orgdff63ef">
+<p>
+Developed in the 70s.
+</p>
+</div>
+
+<ul class="org-ul">
+<li><a id="orgbd82fa4"></a>Porcess<br />
+<div class="outline-text-5" id="text-orgbd82fa4">
+<ol class="org-ol">
+<li>Power on.</li>
+<li>Test power supply.</li>
+<li>Power up the CPU.</li>
+<li>BIOS code from BIOS chip on motherboard copied to memory then executed by CPU.</li>
+<li>BIOS program persom <b>POST (Power On Self Test)</b>
+<ul class="org-ul">
+<li>Checks memory, storage devices, display devices.</li>
+<li>Checks keyboard and mouse.</li>
+<li>Initializes additional BIOS chip if available.</li>
+<li>If any problem occur, it will <i>beep</i>.</li>
+</ul></li>
+<li>Search for bootable partition name MBR.</li>
+</ol>
+</div>
+</li>
+
+<li><a id="orgb6bdf6a"></a>Limitation<br />
+<div class="outline-text-5" id="text-orgb6bdf6a">
+<ol class="org-ol">
+<li>Only supports 16bit instruction set.</li>
+<li>Can only access limited amount of RAM.</li>
+<li>Can only access storage device upto 2TB.</li>
+</ol>
+</div>
+</li>
+</ul>
+</div>
+
+<div id="outline-container-org5c78de0" class="outline-4">
+<h4 id="org5c78de0">UEFI (Universal Extensible Firmware Interface)</h4>
+<div class="outline-text-4" id="text-org5c78de0">
+<p>
+Developed in 2005 to address BIOS limitation &amp; adds additional features.
+</p>
+</div>
+
+<ul class="org-ul">
+<li><a id="orga4a68d5"></a>Pros<br />
+<div class="outline-text-5" id="text-orga4a68d5">
+<ol class="org-ol">
+<li>Supports 32/64 bit instructions set.</li>
+<li>Access to large RAM.</li>
+<li>Can run drivers without any OS.</li>
+<li>Supports over 2TB storage devices using GPT(GUID (Globally Unique Identifires) Partition Table).</li>
+<li>EFI partition stors bootloader but not limited to it.
+<ul class="org-ul">
+<li>Partition can hold other porgrams also like recovery tool that can be run without need of OS in case of any failure.</li>
+</ul></li>
+<li>Provides secure boot.
+<ul class="org-ul">
+<li>It scans OS &amp; drives for digital signed keys to check authenticitym &amp; only run program if its proven.</li>
+<li>But its not restricted to it, custom complied linux can also be used by disabling the secure boot or adding the custom digital key to UEFI.</li>
+</ul></li>
+<li>Provides remote access.</li>
+<li>Provices fast boot.</li>
+<li>Support different CPU architecture.</li>
+</ol>
+</div>
+</li>
+</ul>
+</div>
+
+<div id="outline-container-orga1eb2a4" class="outline-4">
+<h4 id="orga1eb2a4">Know the system</h4>
+<div class="outline-text-4" id="text-orga1eb2a4">
+</div>
+<ul class="org-ul">
+<li><a id="org5eb828f"></a>On Linux<br />
+<div class="outline-text-5" id="text-org5eb828f">
+<dl class="org-dl">
+<dt><code>dmidecode</code></dt><dd>Tool for dumping computer hardware component info.
+<dl class="org-dl">
+<dt>-t</dt><dd>baseboard</dd>
+<dt>-s</dt><dd>bios-version</dd>
+</dl></dd>
+</dl>
+</div>
+</li>
+
+<li><a id="org302ee9c"></a>On Windows<br />
+<div class="outline-text-5" id="text-org302ee9c">
+<dl class="org-dl">
+<dt><code>wmic</code></dt><dd>Hardware level info
+<ul class="org-ul">
+<li>baseboard get product, manufacture</li>
+<li>bios get smbiosversion</li>
+</ul></dd>
+</dl>
+</div>
+</li>
+</ul>
+</div>
+</div>
+
+<div id="outline-container-org24f84e2" class="outline-3">
+<h3 id="org24f84e2"><span class="section-number-3">6.3.</span> MBR/EFI</h3>
+</div>
+
+<div id="outline-container-org1a575b4" class="outline-3">
+<h3 id="org1a575b4"><span class="section-number-3">6.4.</span> Boot Loader</h3>
+</div>
+
+<div id="outline-container-org239340d" class="outline-3">
+<h3 id="org239340d"><span class="section-number-3">6.5.</span> Kernel</h3>
+</div>
+
+<div id="outline-container-org1f80eb5" class="outline-3">
+<h3 id="org1f80eb5"><span class="section-number-3">6.6.</span> Initramfs</h3>
+</div>
+
+<div id="outline-container-org7c45537" class="outline-3">
+<h3 id="org7c45537"><span class="section-number-3">6.7.</span> /sbin/init (parent process)</h3>
+</div>
+
+<div id="outline-container-orga56acef" class="outline-3">
+<h3 id="orga56acef"><span class="section-number-3">6.8.</span> commmand shel using getty</h3>
+</div>
+
+<div id="outline-container-orgf6de0b0" class="outline-3">
+<h3 id="orgf6de0b0"><span class="section-number-3">6.9.</span> GUI (Xwindow or Wayland)</h3>
+</div>
+</section>
+
+<section id="outline-container-org4be9c3d" class="outline-2">
+<h2 id="org4be9c3d"><span class="section-number-2">7.</span> Systemd</h2>
+<div class="outline-text-2" id="text-7">
+<p>
+Systemd is not a single element but a collection of programs, daemons, libraries, technologies and kernel components.
+</p>
+<dl class="org-dl">
+<dt>Unit file</dt><dd><p>
+Small programs known as daemons
+</p>
+<pre class="example" id="orge862496">
+[Unit]
+Description=fast remote file copy program daemon
+ConditionPathExists=/etc/rsyncd.conf
+[Service]
+ExecStart=/usr/bin/rsync --daemon --no-detach
+[Install]
+WantedBy=multi-user.target
+</pre>
+<ul class="org-ul">
+<li>Unit file location <code>/usr/lib/systemd/system/</code> or <code>/lib/systemd/systemd/</code>  (local unit file with highest priority).</li>
+</ul></dd>
+<dt><code>systemctl</code></dt><dd>Status of systemd daemons &amp; configuration.
+<ul class="org-ul">
+<li><code>systemctl list-units --type=service</code></li>
+<li><code>sytemctl list-units-files --type=service</code></li>
+</ul></dd>
+</dl>
+</div>
+</section>
+
+<section id="outline-container-orgd935de7" class="outline-2">
+<h2 id="orgd935de7"><span class="section-number-2">8.</span> Man page</h2>
+<div class="outline-text-2" id="text-8">
+<ul class="org-ul">
+<li>Section Contents
+<ul class="org-ul">
+<li>1 User+ level commands and applications</li>
+<li>2 System calls and kernel error codes</li>
+<li>3 Library calls</li>
+<li>4 Device drivers and network protocols</li>
+<li>5 Standard file formats</li>
+<li>6 Games and demonstrations</li>
+<li>7 Miscellaneous files and documents</li>
+<li>8 System administration commands</li>
+<li>9 Obscure kernel specs and interface</li>
+</ul></li>
+<li id="`man -k &lt;keyword&gt;`">list of man page that have &lt;keyword&gt;
+<ul class="org-ul">
+<li>need to rebuild the file for this database whenever a new man is added
+<ul class="org-ul">
+<li>`makewhatis`(RHEL), `mandb` (ubuntu)</li>
+</ul></li>
+</ul></li>
+<li>nroff for man pages is stored under `/usr/share/man` &amp; compressed with gzip.
+<ul class="org-ul">
+<li>man decompress them on the fly &amp; maintains chache of formatted pages in `/var/cache/man` or `/usr/share/man`.</li>
+<li id="`manpath`">path for man page searching</li>
+<li id="nroff">format doc written in groff CONFUSE</li>
+</ul></li>
+</ul>
+</div>
+</section>
+
+<section id="outline-container-org5243a6b" class="outline-2">
+<h2 id="org5243a6b"><span class="section-number-2">9.</span> Laptop fan configuration</h2>
+<div class="outline-text-2" id="text-9">
+<p>
+laptop was heating up-tick<sub>sched</sub><sub>timer</sub> - 1.68W&#x2026; after restart its gone
+</p>
+<div class="org-src-container">
+<pre class="src src-shell">installed - tlp
+tlp-stat -g
+fancontrol
+pwmconfig ---pwm contorl not found
+not able to control fan
+isw--- not supprt for GF63
+sudo sensors-detect
+/etc/init.d/kmod start
+detecting sensors... second one to restart it to load module
+</pre>
+</div>
+</div>
+</section>
+
+<section id="outline-container-orgb27c87c" class="outline-2">
+<h2 id="orgb27c87c"><span class="section-number-2">10.</span> Command Categorization</h2>
+<div class="outline-text-2" id="text-10">
+</div>
+<div id="outline-container-org3f96a68" class="outline-3">
+<h3 id="org3f96a68"><span class="section-number-3">10.1.</span> Search</h3>
+<div class="outline-text-3" id="text-10-1">
+<table>
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<tbody>
+<tr>
+<td class="org-left">which</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Search shell path for binary</td>
+</tr>
+
+<tr>
+<td class="org-left">whereis</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Search boarder for the binary</td>
+</tr>
+
+<tr>
+<td class="org-left">locate</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Search compiled index of FS to find particular pattern</td>
+</tr>
+
+<tr>
+<td class="org-left">mlocate</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">updatedb</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Runs periodically through cron to update the locate index</td>
+</tr>
+
+<tr>
+<td class="org-left">find</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+
+<div id="outline-container-orgdd32aca" class="outline-3">
+<h3 id="orgdd32aca"><span class="section-number-3">10.2.</span> Networking</h3>
+<div class="outline-text-3" id="text-10-2">
+<table>
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<tbody>
+<tr>
+<td class="org-left">tcpdump</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Get raw packet being sent to &amp; from system.</td>
+</tr>
+
+<tr>
+<td class="org-left">iwctl</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Manages wifi interface through iwd</td>
+</tr>
+
+<tr>
+<td class="org-left">route</td>
+<td class="org-left">route -n</td>
+<td class="org-left">Shows routing table</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+
+<div id="outline-container-org9ef572d" class="outline-3">
+<h3 id="org9ef572d"><span class="section-number-3">10.3.</span> About System</h3>
+<div class="outline-text-3" id="text-10-3">
+<table>
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<tbody>
+<tr>
+<td class="org-left">who</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Shows who is logged in</td>
+</tr>
+
+<tr>
+<td class="org-left">id</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">user &amp; group id</td>
+</tr>
+
+<tr>
+<td class="org-left">date</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">uname</td>
+<td class="org-left"><code>uname -a</code></td>
+<td class="org-left">System info</td>
+</tr>
+
+<tr>
+<td class="org-left">ls</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">whoami</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Shows username</td>
+</tr>
+
+<tr>
+<td class="org-left">findmnt</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">List all mount points</td>
+</tr>
+
+<tr>
+<td class="org-left">lspci</td>
+<td class="org-left"><code>lspci -k</code></td>
+<td class="org-left">List all drivers handled by kernel by default</td>
+</tr>
+
+<tr>
+<td class="org-left">dmesg</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Output kernel&rsquo;s ring buffers</td>
+</tr>
+
+<tr>
+<td class="org-left">lsblk</td>
+<td class="org-left"><code>lsblk -f</code></td>
+<td class="org-left">List all info of the blocks</td>
+</tr>
+
+<tr>
+<td class="org-left">du</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Disk</td>
+</tr>
+
+<tr>
+<td class="org-left">w</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">List users and what they are working on</td>
+</tr>
+
+<tr>
+<td class="org-left">smem</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Reports memory usage using multiple filtering</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Like aggregation of an application (like firefox)</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+
+<div id="outline-container-org1817515" class="outline-3">
+<h3 id="org1817515"><span class="section-number-3">10.4.</span> Systemd</h3>
+<div class="outline-text-3" id="text-10-4">
+<table>
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<tbody>
+<tr>
+<td class="org-left">journalctl</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Outputs all the log of the system in a single file</td>
+</tr>
+
+<tr>
+<td class="org-left">systemctl</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Manages systemd services</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+
+<div id="outline-container-org621836d" class="outline-3">
+<h3 id="org621836d"><span class="section-number-3">10.5.</span> Configure system</h3>
+<div class="outline-text-3" id="text-10-5">
+<table>
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<tbody>
+<tr>
+<td class="org-left">genfstab</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Generate fstab including all file system mounted at that time</td>
+</tr>
+
+<tr>
+<td class="org-left">pacstrap</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Installing packages into a newly installed partitioned</td>
+</tr>
+
+<tr>
+<td class="org-left">arch-chroot</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Take control of newly modified root partition</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+
+<div id="outline-container-org13bcaa7" class="outline-3">
+<h3 id="org13bcaa7"><span class="section-number-3">10.6.</span> File</h3>
+<div class="outline-text-3" id="text-10-6">
+<table>
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<tbody>
+<tr>
+<td class="org-left">cksum</td>
+<td class="org-left"><code>cksum -a algorithm file</code></td>
+<td class="org-left">Checks integrity of the downloaded file</td>
+</tr>
+
+<tr>
+<td class="org-left">file</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Shows all details of any type of file</td>
+</tr>
+
+<tr>
+<td class="org-left">chown</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Change owner and group</td>
+</tr>
+
+<tr>
+<td class="org-left">chmod</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Change file mode bits</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+
+<div id="outline-container-org9cf1125" class="outline-3">
+<h3 id="org9cf1125"><span class="section-number-3">10.7.</span> User</h3>
+<div class="outline-text-3" id="text-10-7">
+<table>
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<tbody>
+<tr>
+<td class="org-left">passwd</td>
+<td class="org-left"><code>passwd -Sa</code></td>
+<td class="org-left">List all existing user account</td>
+</tr>
+
+<tr>
+<td class="org-left">useradd</td>
+<td class="org-left"><code>useadd -m</code></td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">usemod</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">groupmod</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">groups</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">List of groups available</td>
+</tr>
+
+<tr>
+<td class="org-left">userdel</td>
+<td class="org-left"><code>userdel -r</code></td>
+<td class="org-left">Incl. its home dir &amp; mail</td>
+</tr>
+
+<tr>
+<td class="org-left">adduser</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Interactive exp. for useradd, ,chfn, passwd</td>
+</tr>
+
+<tr>
+<td class="org-left">chfn</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Change you fingerprint (the info stored in /etc/passwd)</td>
+</tr>
+
+<tr>
+<td class="org-left">getent</td>
+<td class="org-left"><code>getent group</code></td>
+<td class="org-left">&#xa0;</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+
+<div id="outline-container-org500018c" class="outline-3">
+<h3 id="org500018c"><span class="section-number-3">10.8.</span> Security Research</h3>
+<div class="outline-text-3" id="text-10-8">
+<table>
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<tbody>
+<tr>
+<td class="org-left">arch-audit</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Scans application for any issues</td>
+</tr>
+
+<tr>
+<td class="org-left">exfitool</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Reads/Writes metadata in files</td>
+</tr>
+
+<tr>
+<td class="org-left">binwalk</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Analyse, Reverse engineering, extracting firmware images</td>
+</tr>
+
+<tr>
+<td class="org-left">string</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Finds every readable string a file</td>
+</tr>
+
+<tr>
+<td class="org-left">xxd</td>
+<td class="org-left">xxd -r input output.suffix</td>
+<td class="org-left">Prints in hex or in reverse</td>
+</tr>
+
+<tr>
+<td class="org-left">hexdump</td>
+<td class="org-left">hexdump &#x2013;canonical file</td>
+<td class="org-left">Prints readable ASCII of the hex value next to it</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+
+<div id="outline-container-org4456ae4" class="outline-3">
+<h3 id="org4456ae4"><span class="section-number-3">10.9.</span> Filteration</h3>
+<div class="outline-text-3" id="text-10-9">
+<table>
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<tbody>
+<tr>
+<td class="org-left">sort</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">uniq</td>
+<td class="org-left">&ldquo;sort uniq -u&rdquo;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">tr</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Translate or delete char, from stdin to stdout, basically modifying strings mkdir</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+
+<div id="outline-container-org5a9d87d" class="outline-3">
+<h3 id="org5a9d87d"><span class="section-number-3">10.10.</span> Environment Varibale</h3>
+<div class="outline-text-3" id="text-10-10">
+<table>
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<tbody>
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left"><code>cat &lt; /proc/$PID/environ</code></td>
+<td class="org-left">Get list for environment specific to application</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left"><code>sed 's:\x0:\n:g' /proc/$PID/environ</code></td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">printenv</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">env</td>
+<td class="org-left">~env EDITOR=vim xtrem</td>
+<td class="org-left">Run command under modified env</td>
+</tr>
+</tbody>
+</table>
+
+<div class="org-src-container">
+<pre class="src src-shell"># This does something
+["$(id -u)" -ge 1000] || return
+for i in "$@";
+do
+[-d "$i"]||continue
+echo "$PATH" | grep -Eq "(^|:)$i(:|$)" &amp;&amp; continue
+export PATH="${PATH}:$i"
+done
+</pre>
+</div>
+<pre class="example" id="org8a943e3">
+$# :: stores the number of arg. provided to the shell prg, not including the prg name
+$? :: stores the exit value of last cmd that was executed
+$0 :: stores the first word of the shell prg i.e name of the shell prg.
+$1 $2 $3
+$* :: stores all the arg. that were passed
+$@ :: stores all the arg. in array like format, inside " "
+export PATH="${PATH}:/home//bin"
+source :: reload the file
+</pre>
+</div>
+</div>
+
+<div id="outline-container-org8a353e0" class="outline-3">
+<h3 id="org8a353e0"><span class="section-number-3">10.11.</span> Compression &amp; Decompression</h3>
+<div class="outline-text-3" id="text-10-11">
+<table>
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<tbody>
+<tr>
+<td class="org-left">tar</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Archieving</td>
+</tr>
+
+<tr>
+<td class="org-left">gzip</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Compression</td>
+</tr>
+
+<tr>
+<td class="org-left">bzip2</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">Encoding using huffman and burrower wheeler algo</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</section>
+
+<section id="outline-container-org4a01bd1" class="outline-2">
+<h2 id="org4a01bd1"><span class="section-number-2">11.</span> <code>mime ^text,  label editor = ${VISUAL:-$EDITOR} -- "$@"</code></h2>
+<div class="outline-text-2" id="text-11">
+<ul class="org-ul">
+<li>${VISUAL:-$EDITOR}
+<ul class="org-ul">
+<li>Part of shell parameter expansion. It means &ldquo;use the value of the VISUAL environment variable if it&rsquo;s set, otherwise use the value of the EDITOR environment variable&rdquo;.</li>
+<li>VISUAL and EDITOR are standard environment variables that store the preferred text editor for the user. VISUAL is usually a visual text editor, while EDITOR might be a more basic or command-line based one</li>
+</ul></li>
+<li>&#x2013;
+<ul class="org-ul">
+<li>This is a standard way to indicate the end of command options in many Unix-like command-line interfaces. It tells the command that follows that any subsequent arguments should be treated as positional parameters rather than option.</li>
+</ul></li>
+<li>$@
+<ul class="org-ul">
+<li>This is another shell scripting construct that represents all the positional parameters passed to the script or command. Each parameter is passed as a separate argument to the command.</li>
+</ul></li>
+</ul>
+</div>
+</section>
+
+<section id="outline-container-org8d1518f" class="outline-2">
+<h2 id="org8d1518f"><span class="section-number-2">12.</span> Compression vs Archieving</h2>
+<div class="outline-text-2" id="text-12">
+<p>
+<a href="https://dane-bulat.medium.com/archiving-and-compression-on-linux-an-introduction-3dc2490e1bb7">https://dane-bulat.medium.com/archiving-and-compression-on-linux-an-introduction-3dc2490e1bb7</a>
+</p>
+</div>
+</section>
+
+<section id="outline-container-org30977ca" class="outline-2">
+<h2 id="org30977ca"><span class="section-number-2">13.</span> ACTIVE OverTheWire</h2>
+<div class="outline-text-2" id="text-13">
+</div>
+
+<div id="outline-container-orga6e4b68" class="outline-3">
+<h3 id="orga6e4b68"><span class="section-number-3">13.1.</span> Level code</h3>
+<div class="outline-text-3" id="text-13-1">
+<ol class="org-ol">
+<li></li>
+
+<li></li>
+
+<li></li>
+
+<li></li>
+
+<li>4oQYVPkxZOOEOO5pTW81FB8j8lxXGUQw</li>
+<li>HWasnPhtq9AVKe0dmk45nxy20cvUa6EG</li>
+<li>morbNTDkSW6jIlUc0ymOdMaLnOlFVAaj</li>
+<li>dfwvzFQi4mU0wfNbFOe9RoWskMLg7eEc</li>
+<li>4CKMh1JI91bUIZZPXDqGanal4xvAg0JM</li>
+<li>FGUW5ilLVJrxX9kMYMmlN4MgbpfMiqey</li>
+<li>dtR173fZKb0RRsDFSGsg2RWnpNVj3qRr</li>
+<li>7x16WNeHIi5YkIhWsfFIqoognUTyj9Q4</li>
+<li>FO5dwFsc0cbaIiH0h8J2eUks2vdTDwAn</li>
+<li>MU4VWeTyJk8ROof1qqmcBPaLh7lDCPvS</li>
+<li>8xCjnmgoKbGLhHFAZlGE5Tmu4M2tKJQo</li>
+<li>kSkvUpMQ7lBYyCM4GBPvCvT1BfWRy0Dx</li>
+<li></li>
+</ol>
+</div>
+
+<div id="outline-container-org5ea225a" class="outline-4">
+<h4 id="org5ea225a">14 (Using ssh to connect)</h4>
+<div class="outline-text-4" id="text-org5ea225a">
+<p>
+The problem teaches you read doc on ssh and gets curiosity to understand the inner working of the ssh.
+SSH (Secure shell), for connecting to remote server sercurely.
+</p>
+<ul class="org-ul">
+<li>Doc is extensibly big with many option.</li>
+<li>The solution is to simply tell ssh to locate the private key that requires for authentication.
+Which the ssh could not able to find in .ssh config file, where it searches for the default files.</li>
+<li>ssh works by generating 2 keys, public and private, as the name suggest public you share, private
+you keep secret. This key is generated by both connecting nodes.</li>
+</ul>
+</div>
+</div>
+
+<div id="outline-container-orgbff6122" class="outline-4">
+<h4 id="orgbff6122">15 (Connecting to localhost on port 30000)</h4>
+<div class="outline-text-4" id="text-orgbff6122">
+<p>
+The problem is simple to use nc (netcat) but delusional method of ssh doc reading takes most of the time.
+Netcat is an interesting program,
+</p>
+<ul class="org-ul">
+<li>It allows full scanning of port on a network.</li>
+<li>Can setup server, host html, etc.</li>
+<li>Basically, 1 part of the nc set up as server and we have to connect to it through it.
+<ul class="org-ul">
+<li>Sending current level pswd replies back the next level pswd.</li>
+</ul></li>
+</ul>
+</div>
+</div>
+
+<div id="outline-container-orga24b56c" class="outline-4">
+<h4 id="orga24b56c">16 (Conneting to localhost on port 30001 through SSL)</h4>
+<div class="outline-text-4" id="text-orga24b56c">
+<p>
+SSL (Secure Socket Layer), which is outdated but actually refers to TSL (Transport Security Layer).
+</p>
+<ul class="org-ul">
+<li>SSL encrypt data being transmitted over the internet like all the websites which has <b>https</b> and not http.</li>
+<li>It ensures any man-in-middle only see gibrish.</li>
+<li>SSL certificate which is provided by the hosting platform, does confirm your client is talking to the
+correct website and not a phising website.</li>
+<li>Here, ssl is listening to port 30001 and connecting to it through nc does not work.</li>
+<li>But connecting to it through openssl s<sub>client</sub> ask for input and if current level password provided, then its bingo.</li>
+</ul>
+</div>
+</div>
+
+<div id="outline-container-org523b27e" class="outline-4">
+<h4 id="org523b27e">17 (Finding the correct SSL port)</h4>
+</div>
+</div>
+
+
+
+
+<div id="outline-container-org9c535b6" class="outline-3">
+<h3 id="org9c535b6"><span class="section-number-3">13.2.</span> Base64</h3>
+<div class="outline-text-3" id="text-13-2">
+<p>
+Binary to text encoding scheme.
+<a href="https://en.wikipedia.org/wiki/Base64">https://en.wikipedia.org/wiki/Base64</a>
+<code>base64 -d</code> :: decodes
+</p>
+</div>
+</div>
+
+<div id="outline-container-org3069c54" class="outline-3">
+<h3 id="org3069c54"><span class="section-number-3">13.3.</span> ssh (Secure shell)</h3>
+</div>
+</section>
+
+<section id="outline-container-orgd089d95" class="outline-2">
+<h2 id="orgd089d95"><span class="section-number-2">14.</span> OpenSSL</h2>
+<div class="outline-text-2" id="text-14">
+</div>
+<div id="outline-container-org6b50200" class="outline-3">
+<h3 id="org6b50200"><span class="section-number-3">14.1.</span> Encrypting a Message with a Password</h3>
+<div class="outline-text-3" id="text-14-1">
+<div class="org-src-container">
+<pre class="src src-shell">echo "LinuxConfig.org" | openssl enc -aes-256-cbc -a -salt -pbkdf2 -pass pass:mysecretpassword
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-org55f2d3d" class="outline-3">
+<h3 id="org55f2d3d"><span class="section-number-3">14.2.</span> Decrypting a Message with a Password</h3>
+<div class="outline-text-3" id="text-14-2">
+<div class="org-src-container">
+<pre class="src src-shell">echo "U2FsdGVkX1/POwwfJq2VK3mqDqFO1Ttfuc+q8UuvoQ4Z0F2byx1uNI3NSjeipkAi" | openssl enc -aes-256-cbc -a -d -salt -pbkdf2 -pass pass:mysecretpassword
+</pre>
+</div>
+</div>
+</div>
+
+<div id="outline-container-org1e92c72" class="outline-3">
+<h3 id="org1e92c72"><span class="section-number-3">14.3.</span> Encrypting a file with a Password</h3>
+</div>
+</section>
+
+<section id="outline-container-org20ee203" class="outline-2">
+<h2 id="org20ee203"><span class="section-number-2">15.</span> Filesystem</h2>
+<div class="outline-text-2" id="text-15">
+<table>
+
+
+<colgroup>
+<col  class="org-right" />
+
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<thead>
+<tr>
+<th scope="col" class="org-right">Num</th>
+<th scope="col" class="org-left">Dir</th>
+<th scope="col" class="org-left">Desc</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="org-right">1</td>
+<td class="org-left">/</td>
+<td class="org-left">Root dir, everything is nested under this dir.</td>
+</tr>
+
+<tr>
+<td class="org-right">2</td>
+<td class="org-left">/bin</td>
+<td class="org-left">Binaries and most common built-in programs.</td>
+</tr>
+
+<tr>
+<td class="org-right">3</td>
+<td class="org-left">/boot</td>
+<td class="org-left">Contains kernel boot.</td>
+</tr>
+
+<tr>
+<td class="org-right">4</td>
+<td class="org-left">/dev</td>
+<td class="org-left">Device files.</td>
+</tr>
+
+<tr>
+<td class="org-right">5</td>
+<td class="org-left">/etc</td>
+<td class="org-left">Core system config files.</td>
+</tr>
+
+<tr>
+<td class="org-right">6</td>
+<td class="org-left">/home</td>
+<td class="org-left">Personal user dir.</td>
+</tr>
+
+<tr>
+<td class="org-right">7</td>
+<td class="org-left">/lib</td>
+<td class="org-left">Holds libs files that binary can use</td>
+</tr>
+
+<tr>
+<td class="org-right">8</td>
+<td class="org-left">/media</td>
+<td class="org-left">Attachment point for removable media like usb drive</td>
+</tr>
+
+<tr>
+<td class="org-right">9</td>
+<td class="org-left">/mnt</td>
+<td class="org-left">Temporarily mounted fs.</td>
+</tr>
+
+<tr>
+<td class="org-right">10</td>
+<td class="org-left">/opt</td>
+<td class="org-left">Optional application software package.</td>
+</tr>
+
+<tr>
+<td class="org-right">11</td>
+<td class="org-left">/proc</td>
+<td class="org-left">Information about currently running process.</td>
+</tr>
+
+<tr>
+<td class="org-right">12</td>
+<td class="org-left">/root</td>
+<td class="org-left">The root user&rsquo;s home dir.</td>
+</tr>
+
+<tr>
+<td class="org-right">13</td>
+<td class="org-left">/run</td>
+<td class="org-left">Information about running system since last boot.</td>
+</tr>
+
+<tr>
+<td class="org-right">14</td>
+<td class="org-left">/sbin</td>
+<td class="org-left">Contains special system binaries, only ran by root.</td>
+</tr>
+
+<tr>
+<td class="org-right">15</td>
+<td class="org-left">/srv</td>
+<td class="org-left">Site-specific data which are served by the system.</td>
+</tr>
+
+<tr>
+<td class="org-right">16</td>
+<td class="org-left">/tmp</td>
+<td class="org-left">Storage for temporary files.</td>
+</tr>
+
+<tr>
+<td class="org-right">17</td>
+<td class="org-left">/usr</td>
+<td class="org-left">User installed software and utilities.</td>
+</tr>
+
+<tr>
+<td class="org-right">18</td>
+<td class="org-left">/var</td>
+<td class="org-left">Used for system logging, user tracking, caches, anything that can change.</td>
+</tr>
+</tbody>
+</table>
+</div>
+</section>
+
+<section id="outline-container-orgf8118d8" class="outline-2">
+<h2 id="orgf8118d8"><span class="section-number-2">16.</span> SELinux (Security Enhanced Linux)</h2>
+</section>
+
+
+
+<section id="outline-container-org116b95a" class="outline-2">
+<h2 id="org116b95a"><span class="section-number-2">17.</span> Structure of Linux</h2>
+<div class="outline-text-2" id="text-17">
+
+<div id="org1f3f763" class="figure">
+<p><img src="inline-images/Structure_of_Linux/2024-07-25_20-23-26_Simplified_Structure_of_the_Linux_Kernel.svg" alt="2024-07-25_20-23-26_Simplified_Structure_of_the_Linux_Kernel.svg" class="org-svg" />
+</p>
+</div>
+
+
+<div id="orgbf2e37f" class="figure">
+<p><img src="inline-images/Structure_of_Linux/2024-07-25_20-30-55_ditaa-b9ffae65be16d30be11b5eca188a7a143b1b8227.png" alt="2024-07-25_20-30-55_ditaa-b9ffae65be16d30be11b5eca188a7a143b1b8227.png" />
+</p>
+</div>
+
+<div id="org107a437" class="figure">
+<p><img src="inline-images/Structure_of_Linux/2024-07-25_20-34-37_figure2.jpg" alt="2024-07-25_20-34-37_figure2.jpg" />
+</p>
+</div>
+</div>
+</section>
+
+
+<section id="outline-container-orgba2c5ab" class="outline-2">
+<h2 id="orgba2c5ab"><span class="section-number-2">18.</span> heyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy</h2>
+</section>
+ </template>

--- a/src/components/notes/publish/NtSoftwareEngineering.vue
+++ b/src/components/notes/publish/NtSoftwareEngineering.vue
@@ -1,0 +1,201 @@
+ <template>
+<div id="table-of-contents" role="doc-toc">
+<h2>Table of Contents</h2>
+<div id="text-table-of-contents" role="doc-toc">
+<ul>
+<li><a href="#orgdbc31b2">1. Cloud Computing</a>
+<ul>
+<li><a href="#orgb073329">1.1. Cloud Service</a>
+<ul>
+<li><a href="#org9f659f5">Infra-as-a-Service (IaaS)</a></li>
+<li><a href="#org145a23a">Platform-as-a-Service</a></li>
+<li><a href="#org0a673af">Software-as-a-Service</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#org91d8e3b">2. ACTIVE Resources</a></li>
+<li><a href="#orgb15b948">3. ACTIVE Learn</a></li>
+</ul>
+</div>
+</div>
+
+<section id="outline-container-orgdbc31b2" class="outline-2">
+<h2 id="orgdbc31b2"><span class="section-number-2">1.</span> Cloud Computing</h2>
+<div class="outline-text-2" id="text-1">
+<p>
+Practice of leasing computer resources from a pool of shared capacity.
+</p>
+</div>
+
+<div id="outline-container-orgb073329" class="outline-3">
+<h3 id="orgb073329"><span class="section-number-3">1.1.</span> Cloud Service</h3>
+<div class="outline-text-3" id="text-1-1">
+</div>
+<div id="outline-container-org9f659f5" class="outline-4">
+<h4 id="org9f659f5">Infra-as-a-Service (IaaS)</h4>
+<div class="outline-text-4" id="text-org9f659f5">
+<p>
+Provides hardware level support only.
+User are responsible for OS, networking, security policy and application.
+Raw compute, memory, network, storage resource, VPS (Virtual Private Server)
+</p>
+</div>
+</div>
+
+<div id="outline-container-org145a23a" class="outline-4">
+<h4 id="org145a23a">Platform-as-a-Service</h4>
+<div class="outline-text-4" id="text-org145a23a">
+<p>
+Providing hardware, OS, networking.
+User are responsible for installing &amp; managing application.
+</p>
+</div>
+</div>
+
+<div id="outline-container-org0a673af" class="outline-4">
+<h4 id="org0a673af">Software-as-a-Service</h4>
+</div>
+</div>
+</section>
+
+<section id="outline-container-org91d8e3b" class="outline-2">
+<h2 id="org91d8e3b"><span class="section-number-2">2.</span> ACTIVE Resources</h2>
+<div class="outline-text-2" id="text-2">
+<table>
+
+
+<colgroup>
+<col  class="org-left" />
+
+<col  class="org-left" />
+</colgroup>
+<thead>
+<tr>
+<th scope="col" class="org-left">Link</th>
+<th scope="col" class="org-left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="org-left"><a href="https://github.com/papers-we-love/papers-we-love">https://github.com/papers-we-love/papers-we-love</a></td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left"><a href="https://teachyourselfcs.com/#algorithms">https://teachyourselfcs.com/#algorithms</a></td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left"><a href="https://github.com/ossu/computer-science">https://github.com/ossu/computer-science</a></td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left"><a href="https://www.theodinproject.com/">https://www.theodinproject.com/</a></td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left"><a href="https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/">https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/</a></td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left"><a href="https://abseil.io/resources/swe-book/html/toc.html">https://abseil.io/resources/swe-book/html/toc.html</a></td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left"><a href="https://www.geeksforgeeks.org/software-engineering/">https://www.geeksforgeeks.org/software-engineering/</a></td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left"><a href="https://www.codewars.com/kata/javascript">https://www.codewars.com/kata/javascript</a></td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left"><a href="https://www.freecodecamp.org/">https://www.freecodecamp.org/</a></td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left"><a href="https://ocw.mit.edu/search/">https://ocw.mit.edu/search/</a></td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left"><a href="https://www.w3schools.com/dsa/index.php">https://www.w3schools.com/dsa/index.php</a></td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left"><a href="https://www.w3schools.com/vue/index.php">https://www.w3schools.com/vue/index.php</a></td>
+<td class="org-left">&#xa0;</td>
+</tr>
+
+<tr>
+<td class="org-left">&#xa0;</td>
+<td class="org-left">&#xa0;</td>
+</tr>
+</tbody>
+</table>
+</div>
+</section>
+
+<section id="outline-container-orgb15b948" class="outline-2">
+<h2 id="orgb15b948"><span class="section-number-2">3.</span> ACTIVE Learn</h2>
+<div class="outline-text-2" id="text-3">
+<ul class="org-ul">
+<li class="off"> Software design patterns like MVC,MVVM, etc.</li>
+<li class="off"> SOLID principles (Single Responsibility, open/closed, Liskov substitution,Interface segeration, Dependency Inversion.</li>
+<li class="off"> Architecture
+<ul class="org-ul">
+<li class="off"> Software architecture like monolith, microservice, serverless.</li>
+<li class="off"> RESTful api design principles and GraphQL</li>
+</ul></li>
+<li class="off"> Database design
+<ul class="org-ul">
+<li class="off"> DBMS</li>
+<li class="off"> SQL, Non-SQL</li>
+</ul></li>
+<li class="off"> Authentication &amp; Authorization
+<ul class="org-ul">
+<li class="off"> Authentication methods Oauth, JWT (Json Web Tokens), and sessions.</li>
+<li class="off"> Role based and attribute based authorization systems.</li>
+<li class="off"> Routing and middle work
+Learn how routing works in web applications and how middleware can be used to handle common tasks like authentication and logging.</li>
+</ul></li>
+<li class="off"> Testing and Debugging
+<ul class="org-ul">
+<li class="off"> Learn testing frameworks and write unit tests, integration tests, and end-to-end tests.</li>
+<li class="off"> Version control</li>
+</ul></li>
+<li class="off"> Project Management and Collaboration tools
+<ul class="org-ul">
+<li class="off"> Project management methodologies
+<ul class="org-ul">
+<li class="off"> Agile</li>
+<li class="off"> Scrum</li>
+</ul></li>
+<li class="off"> Collaboration tools
+<ul class="org-ul">
+<li class="off"> Jira</li>
+<li class="off"> Trello</li>
+</ul></li>
+<li class="off"> CI/CD Continuous Integration and Deployment
+Understand how CI/CD pipelines work to automate testing and deployment processes.</li>
+</ul></li>
+<li class="off"> Security best practices
+Study common security vulnerabilities and how to mitigate them.
+<ul class="org-ul">
+<li class="off"> follow OWASP (Open worldwide application security project)</li>
+</ul></li>
+<li class="off"> Kubernetes</li>
+</ul>
+</div>
+</section>
+ </template>

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,7 @@
 // application instance
 import { createApp } from "vue";
+
+import router from "./router";
 import App from "./App.vue";
 
-createApp(App).mount("#app");
+createApp(App).use(router).mount("#app");

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,0 +1,17 @@
+import { createWebHistory, createRouter } from "vue-router";
+
+import HomePage from "@/views/HomePage.vue";
+import NotesVault from "@/views/NotesVault.vue";
+
+const router = createRouter({
+  // FIXME Without a proper server configuration
+  /* the user will get 404 error if they access the link directly. */
+  /* https://router.vuejs.org/guide/essentials/history-mode.html#HTML5-Mode */
+  history: createWebHistory(),
+  routes: [
+    { path: "/", component: HomePage },
+    { path: "/notesvault", component: NotesVault },
+  ],
+});
+
+export default router;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,11 @@ import { createWebHistory, createRouter } from "vue-router";
 import HomePage from "@/views/HomePage.vue";
 import NotesVault from "@/views/NotesVault.vue";
 
+import NtSoftwareEngineering from "@/components/notes/publish/NtSoftwareEngineering.vue";
+import NtLinux from "@/components/notes/publish/NtLinux.vue";
+import NtCpuArchitecture from "@/components/notes/publish/NtCpuArchitecture.vue";
+import NtArch from "@/components/notes/publish/NtArch.vue";
+
 const router = createRouter({
   // FIXME Without a proper server configuration
   /* the user will get 404 error if they access the link directly. */
@@ -10,7 +15,19 @@ const router = createRouter({
   history: createWebHistory(),
   routes: [
     { path: "/", component: HomePage },
-    { path: "/notesvault", component: NotesVault },
+    {
+      path: "/notesvault",
+      component: NotesVault,
+      children: [
+        /* { path: "linux", component: NtLinux }, */
+        { path: "cpuarchitecture", component: NtCpuArchitecture },
+        { path: "softwareengineering", component: NtSoftwareEngineering },
+        { path: "arch", component: NtArch },
+        { path: "cpuarchitecture", component: NtCpuArchitecture },
+        { path: "linux", component: NtLinux },
+        { path: "softwareengineering", component: NtSoftwareEngineering },
+      ],
+    },
   ],
 });
 

--- a/src/views/NotesVault.vue
+++ b/src/views/NotesVault.vue
@@ -1,5 +1,11 @@
-<script setup></script>
+<script setup>
+import NotesContentViewer from "@/components/NotesContentViewer.vue";
+import NotesListDroidNav from "@/components/NotesListDroidNav.vue";
+</script>
 <template>
-  <div class="text-white">Notes page</div>
+  <section id="notes-vault" class="text-white">
+    <NotesListDroidNav />
+    <NotesContentViewer />
+  </section>
 </template>
 <style scoped></style>

--- a/src/views/NotesVault.vue
+++ b/src/views/NotesVault.vue
@@ -1,5 +1,5 @@
 <script setup></script>
 <template>
-  <div>Notes page</div>
+  <div class="text-white">Notes page</div>
 </template>
 <style scoped></style>


### PR DESCRIPTION
     This past 10 or more days
     Worked through the project
     Added workflow for the note publish
     - Now just with "npm run generatent"("nt" for note)
       every linked notes which is in =~/note/org-export/files-approved/make=
       1. Get the list of notes
       2. Run seperate emacs proc (which is fast & without gui)
          Read another init file =~/.dotfiles/org-publish-init.el/=
       3. Exports the notes to another dir =~/notes/org-export/publish=
       4. Then the .html file gets rynced to project dir in =/projects/prjolfreg314/src/components/notes/publish=
       5. All the .html files gets extension changed into .vue
       6. All the .vue files gets add vue =<template></template>=
       7. All the .vue files gets a good name changed from nt-bla-bla.vue to NtBlaBla.vue
       Buttons and links can auto created by just importing the file in nav index.